### PR TITLE
Test/feed comment delete test

### DIFF
--- a/src/main/java/com/sooum/core/domain/card/controller/CommentCardController.java
+++ b/src/main/java/com/sooum/core/domain/card/controller/CommentCardController.java
@@ -43,7 +43,7 @@ public class CommentCardController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/comments/{cardPk}")
+    @DeleteMapping("/{cardPk}")
     public ResponseEntity<Void> deleteCommentCardInfo(@PathVariable("cardPk") Long cardPk) {
         feedService.deleteCommentCard(cardPk);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/sooum/core/domain/card/controller/FeedCardController.java
+++ b/src/main/java/com/sooum/core/domain/card/controller/FeedCardController.java
@@ -51,7 +51,7 @@ public class FeedCardController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/cards/{cardPk}")
+    @DeleteMapping("/{cardPk}")
     public ResponseEntity<Void> deleteFeedCardInfo(@PathVariable("cardPk") Long cardPk) {
         feedService.deleteFeedCard(cardPk);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/sooum/core/domain/card/entity/CommentCard.java
+++ b/src/main/java/com/sooum/core/domain/card/entity/CommentCard.java
@@ -27,12 +27,11 @@ public class CommentCard extends Card {
     private Long parentCardPk;
 
     @NotNull
-    @JoinColumn(name = "MASTER_CARD")
-    @ManyToOne(fetch = FetchType.LAZY)
-    private FeedCard masterCard;
+    @Column(name = "MASTER_CARD_PK")
+    private Long masterCard;
 
     @Builder
-    public CommentCard(String content, FontSize fontSize, Font font, Point location, ImgType imgType, String imgName, boolean isPublic, boolean isStory, Member writer, CardType parentCardType, Long parentCardPk, FeedCard masterCard) {
+    public CommentCard(String content, FontSize fontSize, Font font, Point location, ImgType imgType, String imgName, boolean isPublic, boolean isStory, Member writer, CardType parentCardType, Long parentCardPk, Long masterCard) {
         super(content, fontSize, font, location, imgType, imgName, isPublic, isStory, writer);
         this.parentCardType = parentCardType;
         this.parentCardPk = parentCardPk;

--- a/src/main/java/com/sooum/core/domain/card/service/CommentCardService.java
+++ b/src/main/java/com/sooum/core/domain/card/service/CommentCardService.java
@@ -6,7 +6,6 @@ import com.sooum.core.domain.card.repository.CommentCardRepository;
 import com.sooum.core.global.exceptionmessage.ExceptionMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,12 +18,7 @@ import java.util.NoSuchElementException;
 public class CommentCardService {
     private final CommentCardRepository commentCardRepository;
 
-    public boolean isOnlyChildInDeletedState(Long commentCardPk) {
-        List<CommentCard> childCards = commentCardRepository.findChildCards(commentCardPk);
-        return childCards.size() == 1 && childCards.get(0).isDeleted();
-    }
-
-    public void deleteOnlyChild(Long commentCardPk) {
+    public void deleteOnlyDeletedChild(Long commentCardPk) {
         List<CommentCard> childCards = commentCardRepository.findChildCards(commentCardPk);
         if (childCards.size() == 1 && childCards.get(0).isDeleted()) {
             commentCardRepository.delete(childCards.get(0));
@@ -58,5 +52,9 @@ public class CommentCardService {
     public CommentCard findByPk(Long commentCardPk) {
         return commentCardRepository.findById(commentCardPk)
                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.CARD_NOT_FOUND.getMessage()));
+    }
+
+    public boolean isExistCommentCard(Long commentCardPk) {
+        return commentCardRepository.existsById(commentCardPk);
     }
 }

--- a/src/main/java/com/sooum/core/domain/card/service/FeedCardService.java
+++ b/src/main/java/com/sooum/core/domain/card/service/FeedCardService.java
@@ -45,6 +45,10 @@ public class FeedCardService {
         return feedCardRepository.findById(feedCardPk).orElseThrow(NoSuchElementException::new);
     }
 
+    public boolean isExistFeedCard(Long feedCardPk) {
+        return feedCardRepository.existsById(feedCardPk);
+    }
+
     public FeedCard findByPk(Long feedCardPk) {
         return feedCardRepository.findById(feedCardPk)
                 .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.CARD_NOT_FOUND.getMessage()));

--- a/src/test/java/com/sooum/core/domain/card/controller/PopularFeedControllerTest.java
+++ b/src/test/java/com/sooum/core/domain/card/controller/PopularFeedControllerTest.java
@@ -101,7 +101,7 @@ class PopularFeedControllerTest {
                     .isCommentWritten(false)
                     .commentCnt(10)
                     .build()
-                    .add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(FeedController.class).findFeedCardInfo((long) i)).withRel("detail"));
+                    .add(WebMvcLinkBuilder.linkTo(WebMvcLinkBuilder.methodOn(FeedCardController.class).findFeedCardInfo((long) i)).withRel("detail"));
             responses.add(dto);
         }
         return responses;

--- a/src/test/java/com/sooum/core/domain/card/repository/CardLikeRepositoryTest.java
+++ b/src/test/java/com/sooum/core/domain/card/repository/CardLikeRepositoryTest.java
@@ -7,6 +7,7 @@ import com.sooum.core.domain.card.entity.FeedLike;
 import com.sooum.core.domain.card.entity.font.Font;
 import com.sooum.core.domain.card.entity.fontsize.FontSize;
 import com.sooum.core.domain.card.entity.imgtype.ImgType;
+import com.sooum.core.domain.card.entity.parenttype.CardType;
 import com.sooum.core.domain.card.entity.parenttype.ParentType;
 import com.sooum.core.domain.member.entity.Member;
 import com.sooum.core.domain.member.entity.devicetype.DeviceType;
@@ -145,7 +146,7 @@ class CardLikeRepositoryTest {
                 .isPublic(true)
                 .isStory(false)
                 .writer(writer)
-                .parentCardType(ParentType.FEED_CARD)
+                .parentCardType(CardType.FEED_CARD)
                 .parentCardPk(feedCard.getPk())
                 .masterCard(feedCard)
                 .build();

--- a/src/test/java/com/sooum/core/domain/card/service/CommentLikeServiceTest.java
+++ b/src/test/java/com/sooum/core/domain/card/service/CommentLikeServiceTest.java
@@ -6,6 +6,7 @@ import com.sooum.core.domain.card.entity.FeedCard;
 import com.sooum.core.domain.card.entity.font.Font;
 import com.sooum.core.domain.card.entity.fontsize.FontSize;
 import com.sooum.core.domain.card.entity.imgtype.ImgType;
+import com.sooum.core.domain.card.entity.parenttype.CardType;
 import com.sooum.core.domain.card.entity.parenttype.ParentType;
 import com.sooum.core.domain.card.repository.CommentLikeRepository;
 import com.sooum.core.domain.member.entity.Member;
@@ -119,7 +120,7 @@ class CommentLikeServiceTest {
                 .isPublic(true)
                 .isStory(false)
                 .writer(writer)
-                .parentCardType(ParentType.FEED_CARD)
+                .parentCardType(CardType.FEED_CARD)
                 .parentCardPk(feedCard.getPk())
                 .masterCard(feedCard)
                 .build();

--- a/src/test/java/com/sooum/core/domain/card/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/sooum/core/domain/card/service/FeedLikeServiceTest.java
@@ -6,6 +6,7 @@ import com.sooum.core.domain.card.entity.FeedLike;
 import com.sooum.core.domain.card.entity.font.Font;
 import com.sooum.core.domain.card.entity.fontsize.FontSize;
 import com.sooum.core.domain.card.entity.imgtype.ImgType;
+import com.sooum.core.domain.card.entity.parenttype.CardType;
 import com.sooum.core.domain.card.entity.parenttype.ParentType;
 import com.sooum.core.domain.card.repository.FeedLikeRepository;
 import com.sooum.core.domain.member.entity.Member;
@@ -114,7 +115,7 @@ class FeedLikeServiceTest {
                 .isPublic(true)
                 .isStory(false)
                 .writer(writer)
-                .parentCardType(ParentType.FEED_CARD)
+                .parentCardType(CardType.FEED_CARD)
                 .parentCardPk(feedCard.getPk())
                 .masterCard(feedCard)
                 .build();


### PR DESCRIPTION
참고 사항: 카드 노드를 중간에 끊어야 하는 경우 마스터카드 연관관계가 설정되어 있으면 상기 로직이 불가능하기 때문에 

> FeedCard Entity 의 masterCard column의 연관관계를 제거하고 Long type의 단순 컬럼으로 변경하였습니다