### PR TITLE
feat/프로필 페이지의 방문자수와 팔로워,팔로잉,닉네임 등 정보 조회 api

### DIFF
--- a/src/main/java/com/sooum/core/domain/card/repository/FeedCardRepository.java
+++ b/src/main/java/com/sooum/core/domain/card/repository/FeedCardRepository.java
@@ -1,6 +1,7 @@
 package com.sooum.core.domain.card.repository;
 
 import com.sooum.core.domain.card.entity.FeedCard;
+import com.sooum.core.domain.member.entity.Member;
 import org.locationtech.jts.geom.Point;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -55,4 +56,7 @@ public interface FeedCardRepository extends JpaRepository<FeedCard, Long> {
 
     @Query("select f from FeedCard f where f.pk = :feedCardPk")
     FeedCard findFeedCard(@Param("feedCardPk") Long feedCardPk);
+
+    @Query("select count(f) from FeedCard f where f.writer = :cardOwnerMember")
+    Long findFeedCardCnt(@Param("cardOwnerMember") Member cardOwnerMember);
 }

--- a/src/main/java/com/sooum/core/domain/card/service/FeedCardService.java
+++ b/src/main/java/com/sooum/core/domain/card/service/FeedCardService.java
@@ -2,6 +2,7 @@ package com.sooum.core.domain.card.service;
 
 import com.sooum.core.domain.card.entity.FeedCard;
 import com.sooum.core.domain.card.repository.FeedCardRepository;
+import com.sooum.core.domain.member.entity.Member;
 import com.sooum.core.global.exceptionmessage.ExceptionMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -56,5 +57,9 @@ public class FeedCardService {
 
     public void saveFeedCard(FeedCard feedCard) {
         feedCardRepository.save(feedCard);
+    }
+
+    public Long findFeedCardCnt(Member cardOwnerMember) {
+        return feedCardRepository.findFeedCardCnt(cardOwnerMember);
     }
 }

--- a/src/main/java/com/sooum/core/domain/follow/controller/FollowController.java
+++ b/src/main/java/com/sooum/core/domain/follow/controller/FollowController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/follow")
+@RequestMapping("/follower")
 @RequiredArgsConstructor
 public class FollowController {
     private final FollowManagementService followManagementService;

--- a/src/main/java/com/sooum/core/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sooum/core/domain/follow/repository/FollowRepository.java
@@ -17,4 +17,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Modifying
     @Query("delete from Follow f where f.fromMember = :fromMember and f.toMember = :toMember")
     void deleteFollower(@Param("fromMember") Member fromMember, @Param("toMember") Member toMember);
+
+    @Query("select count(f) from Follow f where f.toMember = :profileOwner")
+    Long findFollowerCnt(@Param("profileOwner") Member profileOwner);
+
+    @Query("select count(f) from Follow f where f.fromMember = :profileOwner")
+    Long findFollowingCnt(@Param("profileOwner") Member profileOwner);
 }

--- a/src/main/java/com/sooum/core/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sooum/core/domain/follow/service/FollowService.java
@@ -30,4 +30,12 @@ public class FollowService {
     public void deleteFollower(Member fromMember, Member toMember) {
         followRepository.deleteFollower(fromMember, toMember);
     }
+
+    public Long findFollowerCnt(Member profileOwner) {
+        return followRepository.findFollowerCnt(profileOwner);
+    }
+
+    public Long findFollowingCnt(Member profileOwner) {
+        return followRepository.findFollowingCnt(profileOwner);
+    }
 }

--- a/src/main/java/com/sooum/core/domain/img/service/AWSImgService.java
+++ b/src/main/java/com/sooum/core/domain/img/service/AWSImgService.java
@@ -46,6 +46,7 @@ public class AWSImgService implements ImgService{
 
     private static final String DEFAULT_IMG = "card/default/";
     private static final String USER_IMG = "card/user/";
+    private static final String PROFILE_IMG = "profile/";
     private static final Duration EXPIRY_TIME = Duration.ofMinutes(1L);
     private static final int DEFAULT_IMG_CNT = 8;
     private static final String DEFAULT_IMG_EXTENSION = "jpeg";
@@ -167,5 +168,13 @@ public class AWSImgService implements ImgService{
             return false;
         }
         return true;
+    }
+
+    @Override
+    public Link findProfileImgUrl(String imgName) {
+        if (imgName == null) {
+            return null;
+        }
+        return createGetPresignedLink(PROFILE_IMG, imgName);
     }
 }

--- a/src/main/java/com/sooum/core/domain/img/service/ImgService.java
+++ b/src/main/java/com/sooum/core/domain/img/service/ImgService.java
@@ -15,4 +15,5 @@ public interface ImgService {
     default boolean isModeratingImg(String imgName){
         return false;
     }
+    default Link findProfileImgUrl(String imgName){return null;}
 }

--- a/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/profile")
+@RequestMapping("/profiles")
 @RequiredArgsConstructor
 public class ProfileController {
 

--- a/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
@@ -1,0 +1,39 @@
+package com.sooum.core.domain.member.controller;
+
+import com.sooum.core.domain.member.dto.ProfileDto;
+import com.sooum.core.domain.member.service.ProfileService;
+import com.sooum.core.global.auth.annotation.CurrentUser;
+import com.sooum.core.global.responseform.ResponseEntityModel;
+import com.sooum.core.global.responseform.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/profile")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @GetMapping("/{memberPk}")
+    ResponseEntity<ResponseEntityModel<ProfileDto.ProfileInfoResponse>>
+    findProfileInfo(@PathVariable("memberPk") Long profileOwnerPk,
+                    @CurrentUser Long memberPk) {
+
+        return ResponseEntity.ok(ResponseEntityModel.<ProfileDto.ProfileInfoResponse>builder()
+                .status(ResponseStatus.builder()
+                        .httpStatus(HttpStatus.OK)
+                        .httpCode(HttpStatus.OK.value())
+                        .responseMessage("retrieve success")
+                        .build())
+                .content(profileService.findProfileInfo(profileOwnerPk, memberPk))
+                .build());
+    }
+}

--- a/src/main/java/com/sooum/core/domain/member/dto/ProfileDto.java
+++ b/src/main/java/com/sooum/core/domain/member/dto/ProfileDto.java
@@ -1,0 +1,19 @@
+package com.sooum.core.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.hateoas.Link;
+
+public class ProfileDto {
+    @Getter
+    @Builder
+    public static class ProfileInfoResponse{
+        private String nickname;
+        private String currentDayVisitors;
+        private String totalVisitorCnt;
+        private Link profileImg;
+        private String cardCnt;
+        private String followingCnt;
+        private String followerCnt;
+    }
+}

--- a/src/main/java/com/sooum/core/domain/member/entity/Member.java
+++ b/src/main/java/com/sooum/core/domain/member/entity/Member.java
@@ -6,13 +6,12 @@ import com.sooum.core.domain.member.entity.devicetype.DeviceType;
 import io.hypersistence.utils.hibernate.id.Tsid;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,6 +41,10 @@ public class Member extends BaseEntity {
     @Column(name = "BAN_COUNT")
     private int banCount;
 
+    @NotNull
+    @Column(name = "TOTAL_VISITOR_CNT")
+    private long totalVisitorCnt;
+
     @Column(name = "DELETED_AT")
     private LocalDateTime deletedAt;
 
@@ -52,11 +55,9 @@ public class Member extends BaseEntity {
     @Column(name = "ROLE")
     private Role role;
 
-    @JoinColumn(name = "PROFILE_CARD")
-    @OneToOne(fetch = FetchType.LAZY)
-    private FeedCard profileCard;
-
-    //TODO: profileImageUrl 추가
+    @Setter
+    @Column(name = "PROFILE_IMG_NAME")
+    private String profileImgName;
 
     @Builder
     public Member(String deviceId, DeviceType deviceType, String firebaseToken, String nickname, boolean isAllowNotify) {
@@ -66,9 +67,10 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.isAllowNotify = isAllowNotify;
         this.banCount = 0;
+        this.totalVisitorCnt = 0;
         this.deletedAt = null;
         this.untilBan = null;
-        this.profileCard = null;
+        this.profileImgName = null;
         this.role = Role.USER;
     }
 

--- a/src/main/java/com/sooum/core/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/sooum/core/domain/member/repository/MemberRepository.java
@@ -1,7 +1,12 @@
 package com.sooum.core.domain.member.repository;
 
 import com.sooum.core.domain.member.entity.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +15,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByDeviceId(String deviceId);
 
     Boolean existsByDeviceId(String deviceId);
+
+    @Modifying
+    @Query("update Member m set m.totalVisitorCnt = m.totalVisitorCnt + 1 where m = :profileOwnerMember")
+    void incrementTotalVisitorCnt(@Param("profileOwnerMember") Member profileOwnerMember);
+
+    @Query("select m.totalVisitorCnt from Member m where m = :profileOwner")
+    Long findTotalVisitorCnt(@Param("profileOwner") Member profileOwner);
 }

--- a/src/main/java/com/sooum/core/domain/member/service/MemberInfoService.java
+++ b/src/main/java/com/sooum/core/domain/member/service/MemberInfoService.java
@@ -1,5 +1,6 @@
 package com.sooum.core.domain.member.service;
 
+import com.sooum.core.domain.img.service.ImgService;
 import com.sooum.core.domain.member.dto.AuthDTO.Login;
 import com.sooum.core.domain.member.dto.AuthDTO.LoginResponse;
 import com.sooum.core.domain.member.dto.AuthDTO.ReissuedToken;
@@ -33,6 +34,7 @@ public class MemberInfoService {
     private final MemberService memberService;
     private final BlacklistService blacklistService;
     private final RsaService rsaService;
+    private final ImgService imgService;
 
     public LoginResponse login(Login dto) {
         String deviceId = rsaService.decodeDeviceId(dto.encryptedDeviceId());
@@ -77,7 +79,7 @@ public class MemberInfoService {
         return MemberDto.DefaultMemberResponse.builder()
                 .id(member.getPk().toString())
                 .nickname(member.getNickname())
-                .profileImgUrl(null) //TODO: 프로필 이미지 URL 추가
+                .profileImgUrl(imgService.findProfileImgUrl(member.getProfileImgName()))
                 .build();
     }
 }

--- a/src/main/java/com/sooum/core/domain/member/service/MemberService.java
+++ b/src/main/java/com/sooum/core/domain/member/service/MemberService.java
@@ -34,4 +34,12 @@ public class MemberService {
     public Member save(MemberInfo dto, String deviceId) {
         return memberRepository.save(memberMapper.from(dto, deviceId));
     }
+
+    public void incrementTotalVisitorCnt(Member profileOwnerMember) {
+        memberRepository.incrementTotalVisitorCnt(profileOwnerMember);
+    }
+
+    public Long findTotalVisitorCnt(Member profileOwnerMember) {
+        return memberRepository.findTotalVisitorCnt(profileOwnerMember);
+    }
 }

--- a/src/main/java/com/sooum/core/domain/member/service/ProfileService.java
+++ b/src/main/java/com/sooum/core/domain/member/service/ProfileService.java
@@ -1,0 +1,51 @@
+package com.sooum.core.domain.member.service;
+
+import com.sooum.core.domain.card.service.FeedCardService;
+import com.sooum.core.domain.follow.service.FollowService;
+import com.sooum.core.domain.img.service.ImgService;
+import com.sooum.core.domain.member.dto.ProfileDto;
+import com.sooum.core.domain.member.entity.Member;
+import com.sooum.core.domain.visitor.service.VisitorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+    private final VisitorService visitorService;
+    private final MemberService memberService;
+    private final FeedCardService feedCardService;
+    private final FollowService followService;
+    private final ImgService imgService;
+
+    @Transactional
+    public ProfileDto.ProfileInfoResponse findProfileInfo(Long profileOwnerPk, Long memberPk) {
+        Member profileOwner = memberService.findByPk(profileOwnerPk);
+        Member visitor = memberService.findByPk(memberPk);
+        saveVisitor(profileOwner, visitor);
+
+        Long totalVisitorCnt = memberService.findTotalVisitorCnt(profileOwner);
+        Long currentDateVisitorCnt = visitorService.findCurrentDateVisitorCnt(profileOwner);
+        Long feedCardCnt = feedCardService.findFeedCardCnt(profileOwner);
+        Long followerCnt = followService.findFollowerCnt(profileOwner);
+        Long followingCnt = followService.findFollowingCnt(profileOwner);
+
+        return ProfileDto.ProfileInfoResponse.builder()
+                .nickname(profileOwner.getNickname())
+                .currentDayVisitors(String.valueOf(currentDateVisitorCnt))
+                .totalVisitorCnt(String.valueOf(totalVisitorCnt))
+                .profileImg(imgService.findProfileImgUrl(profileOwner.getProfileImgName()))
+                .cardCnt(String.valueOf(feedCardCnt))
+                .followerCnt(String.valueOf(followerCnt))
+                .followingCnt(String.valueOf(followingCnt))
+                .build();
+    }
+
+    private void saveVisitor(Member profileOwner, Member visitor) {
+        boolean isNewVisitor = visitorService.saveVisitor(profileOwner, visitor);
+        if (isNewVisitor) {
+            memberService.incrementTotalVisitorCnt(profileOwner);
+        }
+    }
+}

--- a/src/main/java/com/sooum/core/domain/visitor/entity/Visitor.java
+++ b/src/main/java/com/sooum/core/domain/visitor/entity/Visitor.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
 
 @Getter
 @Entity
-@Table(indexes = @Index(name = "IDX_VISIT_DATE", columnList = "createdAt"))
+@Table(indexes = @Index(name = "IDX_VISIT_DATE", columnList = "visitDate"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Visitor extends BaseEntity {
     @Id @Tsid

--- a/src/main/java/com/sooum/core/domain/visitor/entity/Visitor.java
+++ b/src/main/java/com/sooum/core/domain/visitor/entity/Visitor.java
@@ -1,0 +1,41 @@
+package com.sooum.core.domain.visitor.entity;
+
+import com.sooum.core.domain.common.entity.BaseEntity;
+import com.sooum.core.domain.member.entity.Member;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(indexes = @Index(name = "IDX_VISIT_DATE", columnList = "createdAt"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Visitor extends BaseEntity {
+    @Id @Tsid
+    private Long pk;
+
+    @NotNull
+    @Column(name = "VISIT_DATE")
+    private LocalDate visitDate;
+
+    @JoinColumn(name = "PROFILE_OWNER", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member profileOwner;
+
+    @JoinColumn(name = "VISITOR", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member visitor;
+
+    @Builder
+    public Visitor(Member profileOwner, Member visitor) {
+        this.profileOwner = profileOwner;
+        this.visitor = visitor;
+        this.visitDate = LocalDate.now();
+    }
+}

--- a/src/main/java/com/sooum/core/domain/visitor/repository/VisitorRepository.java
+++ b/src/main/java/com/sooum/core/domain/visitor/repository/VisitorRepository.java
@@ -1,0 +1,22 @@
+package com.sooum.core.domain.visitor.repository;
+
+import com.sooum.core.domain.member.entity.Member;
+import com.sooum.core.domain.visitor.entity.Visitor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface VisitorRepository extends JpaRepository<Visitor, Long> {
+
+    @Query("select v " +
+            "from Visitor v " +
+            "where v.visitDate = current_date and v.profileOwner = :profileOwner and v.visitor = :visitor")
+    Optional<Visitor> findCurrentDateVisitor(@Param("profileOwner") Member profileOwner, @Param("visitor") Member visitor);
+
+    @Query("select count(v) " +
+            "from Visitor v " +
+            "where v.profileOwner = :profileOwnerMember and v.visitDate = current_date ")
+    Long findCurrentDateVisitorCnt(@Param("profileOwnerMember") Member profileOwnerMember);
+}

--- a/src/main/java/com/sooum/core/domain/visitor/service/VisitorService.java
+++ b/src/main/java/com/sooum/core/domain/visitor/service/VisitorService.java
@@ -1,0 +1,34 @@
+package com.sooum.core.domain.visitor.service;
+
+import com.sooum.core.domain.member.entity.Member;
+import com.sooum.core.domain.visitor.entity.Visitor;
+import com.sooum.core.domain.visitor.repository.VisitorRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class VisitorService {
+    private final VisitorRepository visitorRepository;
+    public boolean saveVisitor(Member profileOwnerMember, Member visitorMember){
+
+        if (isNewVisitor(profileOwnerMember, visitorMember)) {
+            visitorRepository.save(Visitor.builder()
+                    .profileOwner(profileOwnerMember)
+                    .visitor(visitorMember)
+                    .build());
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isNewVisitor(Member profileOwner, Member visitorMember) {
+        return visitorRepository.findCurrentDateVisitor(profileOwner, visitorMember).isEmpty();
+    }
+
+    public Long findCurrentDateVisitorCnt(Member profileOwnerMember){
+        return visitorRepository.findCurrentDateVisitorCnt(profileOwnerMember);
+    }
+}


### PR DESCRIPTION
프로필 정보 조회 API입니다.
당일 방문자 수와 전체 방문자 수 구분을 위해 방문자 기록을 저장하는 테이블(visitor)과 멤버 테이블에 전체 방문자 수를 저장하는 레코드를 새로 생성하였습니다.
방문자 기록 테이블에 당일 기록이 없는 최초 조회라면 레코드가 새로 저장되며 동시에 멤버에 전체 방문자 수 카운트가 하나 증가하도록 구현하였습니다.