### PR TITLE
refactor: 팔로우 저장 & 수정 트랜잭션 전파 설정 변경

### DIFF
--- a/src/main/java/com/sooum/core/domain/follow/service/FollowManagementService.java
+++ b/src/main/java/com/sooum/core/domain/follow/service/FollowManagementService.java
@@ -12,11 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class FollowManagementService {
     private final FollowService followService;
     private final MemberService memberService;
 
+    @Transactional
     public void saveFollower(final Long fromMemberId, final Long toMemberId) {
         Member fromMember = memberService.findByPk(fromMemberId);
         Member toMember = memberService.findByPk(toMemberId);
@@ -26,6 +26,7 @@ public class FollowManagementService {
         followService.saveFollower(fromMember, toMember);
     }
 
+    @Transactional
     public void deleteFollower(final Long fromMemberId, final Long toMemberId) {
         Member fromMember = memberService.findByPk(fromMemberId);
         Member toMember = memberService.findByPk(toMemberId);

--- a/src/main/java/com/sooum/core/domain/follow/service/FollowService.java
+++ b/src/main/java/com/sooum/core/domain/follow/service/FollowService.java
@@ -10,7 +10,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class FollowService {
     private final FollowRepository followRepository;
 
@@ -18,7 +17,7 @@ public class FollowService {
         return followRepository.findFollow(fromMember, toMember).isPresent();
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void saveFollower(Member fromMember, Member toMember) {
         followRepository.save(Follow.builder()
                 .fromMember(fromMember)
@@ -26,7 +25,7 @@ public class FollowService {
                 .build());
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void deleteFollower(Member fromMember, Member toMember) {
         followRepository.deleteFollower(fromMember, toMember);
     }


### PR DESCRIPTION
팔로우 저장 및 삭제 메서드에 트랜젝션 어노테이션 추가 및 저장 시 새로운 트랜잭션에서 저장되는 로직에서 하나의 트랜젝션 범위에서 저장되도록 수정