### PR TITLE
feat: 프로필 수정 관련 API와 계정 이관 관련 API 구현

### DIFF
--- a/src/main/java/com/sooum/core/domain/img/service/AWSImgService.java
+++ b/src/main/java/com/sooum/core/domain/img/service/AWSImgService.java
@@ -162,10 +162,11 @@ public class AWSImgService implements ImgService{
                     .bucket(bucket)
                     .key(USER_IMG + imgName)
                     .build());
-            s3Client.close();
         } catch (Exception e) {
             log.error("{}",e.getMessage());
             return false;
+        } finally {
+            s3Client.close();
         }
         return true;
     }

--- a/src/main/java/com/sooum/core/domain/member/controller/MemberSettingController.java
+++ b/src/main/java/com/sooum/core/domain/member/controller/MemberSettingController.java
@@ -1,0 +1,50 @@
+package com.sooum.core.domain.member.controller;
+
+import com.sooum.core.domain.member.dto.AccountTransferDto;
+import com.sooum.core.domain.member.dto.ProfileDto;
+import com.sooum.core.domain.member.service.AccountTransferService;
+import com.sooum.core.global.auth.annotation.CurrentUser;
+import com.sooum.core.global.responseform.ResponseEntityModel;
+import com.sooum.core.global.responseform.ResponseStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/settings")
+public class MemberSettingController {
+    private final AccountTransferService accountTransferService;
+
+    @GetMapping("/transfer")
+    public ResponseEntity<ResponseEntityModel<ProfileDto.AccountTransferCodeResponse>> findOrSaveAccountTransferId(@CurrentUser Long memberPk) {
+        return ResponseEntity.ok(ResponseEntityModel.<ProfileDto.AccountTransferCodeResponse>builder()
+                .status(ResponseStatus.builder()
+                        .httpStatus(HttpStatus.OK)
+                        .httpCode(HttpStatus.OK.value())
+                        .responseMessage("Transfer code retrieve successfully")
+                        .build())
+                .content(accountTransferService.findOrSaveAccountTransferId(memberPk))
+                .build());
+    }
+
+    @PostMapping("/transfer")
+    public ResponseEntity<Void> transferAccount(@RequestBody AccountTransferDto.TransferAccount transferAccount) {
+        accountTransferService.transferAccount(transferAccount);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/transfer")
+    public ResponseEntity<ResponseEntityModel<ProfileDto.AccountTransferCodeResponse>> updateAccountTransferId(@CurrentUser Long memberPk) {
+        return ResponseEntity.ok(ResponseEntityModel.<ProfileDto.AccountTransferCodeResponse>builder()
+                .status(ResponseStatus.builder()
+                        .httpStatus(HttpStatus.OK)
+                        .httpCode(HttpStatus.OK.value())
+                        .responseMessage("Transfer code retrieve successfully")
+                        .build())
+                .content(accountTransferService.updateAccountTransfer(memberPk))
+                .build());
+    }
+}

--- a/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
+++ b/src/main/java/com/sooum/core/domain/member/controller/ProfileController.java
@@ -5,14 +5,12 @@ import com.sooum.core.domain.member.service.ProfileService;
 import com.sooum.core.global.auth.annotation.CurrentUser;
 import com.sooum.core.global.responseform.ResponseEntityModel;
 import com.sooum.core.global.responseform.ResponseStatus;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -35,5 +33,29 @@ public class ProfileController {
                         .build())
                 .content(profileService.findProfileInfo(profileOwnerPk, memberPk))
                 .build());
+    }
+
+    @GetMapping("/nickname/{nickname}/available")
+    public ResponseEntity<ResponseEntityModel<ProfileDto.NicknameAvailable>> verifyNicknameAvailable(@PathVariable("nickname") String nickname) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
+                ResponseEntityModel.<ProfileDto.NicknameAvailable>builder()
+                        .status(
+                                ResponseStatus.builder()
+                                        .httpStatus(HttpStatus.OK)
+                                        .httpCode(HttpStatus.OK.value())
+                                        .responseMessage("Verify nickname successfully")
+                                        .build()
+                        )
+                        .content(profileService.verifyNicknameAvailable(nickname))
+                        .build()
+        );
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<Void> updateProfile(@RequestBody @Valid ProfileDto.ProfileUpdate profileUpdate,
+                                              @CurrentUser Long memberPk) {
+        profileService.updateProfile(profileUpdate, memberPk);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sooum/core/domain/member/dto/AccountTransferDto.java
+++ b/src/main/java/com/sooum/core/domain/member/dto/AccountTransferDto.java
@@ -1,0 +1,19 @@
+package com.sooum.core.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class AccountTransferDto {
+
+    @Getter
+    public static class TransferAccount {
+        private final String transferId;
+        private final String encryptedDeviceId;
+
+        @Builder
+        public TransferAccount(String encryptedDeviceId, String transferId) {
+            this.encryptedDeviceId = encryptedDeviceId;
+            this.transferId = transferId;
+        }
+    }
+}

--- a/src/main/java/com/sooum/core/domain/member/dto/ProfileDto.java
+++ b/src/main/java/com/sooum/core/domain/member/dto/ProfileDto.java
@@ -1,7 +1,10 @@
 package com.sooum.core.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.hateoas.Link;
 
 public class ProfileDto {
@@ -15,5 +18,40 @@ public class ProfileDto {
         private String cardCnt;
         private String followingCnt;
         private String followerCnt;
+    }
+
+    @Getter
+    @Setter
+    public static class NicknameAvailable {
+        @JsonProperty(value = "isAvailable")
+        private boolean isAvailable;
+
+        @Builder
+        public NicknameAvailable(boolean isAvailable) {
+            this.isAvailable = isAvailable;
+        }
+    }
+
+    @Getter
+    public static class ProfileUpdate {
+        @Size(min = 1, max = 8)
+        private final String nickname;
+        private final String profileImg;
+
+        @Builder
+        public ProfileUpdate(String nickname, String profileImg) {
+            this.nickname = nickname;
+            this.profileImg = profileImg;
+        }
+    }
+
+    @Getter
+    public static class AccountTransferCodeResponse {
+        private final String transferCode;
+
+        @Builder
+        public AccountTransferCodeResponse(String transferCode) {
+            this.transferCode = transferCode;
+        }
     }
 }

--- a/src/main/java/com/sooum/core/domain/member/entity/AccountTransfer.java
+++ b/src/main/java/com/sooum/core/domain/member/entity/AccountTransfer.java
@@ -20,7 +20,7 @@ public class AccountTransfer extends BaseEntity {
     private Long pk;
 
     @NotNull
-    @Column(name = "TRANSFER_ID")
+    @Column(name = "TRANSFER_ID", unique = true)
     private String transferId;
 
     @NotNull
@@ -34,8 +34,28 @@ public class AccountTransfer extends BaseEntity {
 
     @Builder
     public AccountTransfer(Member member) {
-        this.transferId = UUID.randomUUID().toString();
+        this.transferId = createTransferId(member.getNickname());
         this.expirationDate = LocalDateTime.now().plusDays(1L);
         this.member = member;
+    }
+
+    private String createTransferId(String nickname) {
+        String[] uuidSplit = UUID.randomUUID().toString().split("-");
+        StringBuilder uuidResult = new StringBuilder();
+
+        for (String uuid : uuidSplit) {
+            uuidResult.append(uuid.charAt(0));
+        }
+
+        return nickname + uuidResult;
+    }
+
+    public void updateTransferId (String nickname) {
+        this.transferId = createTransferId(nickname);
+        this.expirationDate = LocalDateTime.now().plusDays(1L);
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expirationDate);
     }
 }

--- a/src/main/java/com/sooum/core/domain/member/entity/Member.java
+++ b/src/main/java/com/sooum/core/domain/member/entity/Member.java
@@ -78,4 +78,13 @@ public class Member extends BaseEntity {
         banCount++;
         role = Role.BANNED;
     }
+
+    public void updateProfile(String nickname, String profileImgName) {
+        this.nickname = nickname;
+        this.profileImgName = profileImgName;
+    }
+
+    public void updateDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
 }

--- a/src/main/java/com/sooum/core/domain/member/repository/AccountTransferRepository.java
+++ b/src/main/java/com/sooum/core/domain/member/repository/AccountTransferRepository.java
@@ -1,0 +1,11 @@
+package com.sooum.core.domain.member.repository;
+
+import com.sooum.core.domain.member.entity.AccountTransfer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AccountTransferRepository extends JpaRepository<AccountTransfer, Long> {
+    Optional<AccountTransfer> findByMember_Pk(Long memberPk);
+    Optional<AccountTransfer> findByTransferId(String transferId);
+}

--- a/src/main/java/com/sooum/core/domain/member/service/AccountTransferService.java
+++ b/src/main/java/com/sooum/core/domain/member/service/AccountTransferService.java
@@ -1,0 +1,82 @@
+package com.sooum.core.domain.member.service;
+
+import com.sooum.core.domain.member.dto.AccountTransferDto;
+import com.sooum.core.domain.member.dto.ProfileDto;
+import com.sooum.core.domain.member.entity.AccountTransfer;
+import com.sooum.core.domain.member.entity.Member;
+import com.sooum.core.domain.member.repository.AccountTransferRepository;
+import com.sooum.core.domain.rsa.service.RsaService;
+import com.sooum.core.global.exceptionmessage.ExceptionMessage;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AccountTransferService {
+    private final MemberService memberService;
+    private final AccountTransferRepository accountTransferRepository;
+    private final RsaService rsaService;
+
+    @Transactional
+    public ProfileDto.AccountTransferCodeResponse findOrSaveAccountTransferId(Long memberPk) {
+        Optional<AccountTransfer> findAccountTransfer = accountTransferRepository.findByMember_Pk(memberPk);
+
+        if (findAccountTransfer.isPresent()) {
+            if (!findAccountTransfer.get().isExpired()) {
+                return ProfileDto.AccountTransferCodeResponse.builder()
+                        .transferCode(findAccountTransfer.get().getTransferId())
+                        .build();
+            }
+
+            if (findAccountTransfer.get().isExpired()){
+                accountTransferRepository.delete(findAccountTransfer.get());
+            }
+        }
+
+        AccountTransfer saveAccountTransfer = saveAccountTransfer(memberPk);
+        return ProfileDto.AccountTransferCodeResponse.builder()
+                .transferCode(saveAccountTransfer.getTransferId())
+                .build();
+    }
+
+    @Transactional
+    public AccountTransfer saveAccountTransfer(Long memberPk) {
+        return accountTransferRepository.save(AccountTransfer.builder()
+                .member(memberService.findByPk(memberPk))
+                .build());
+    }
+
+    @Transactional
+    public ProfileDto.AccountTransferCodeResponse updateAccountTransfer(Long memberPk) {
+        AccountTransfer findAccountTransfer = findAccountTransfer(memberPk);
+        Member member = memberService.findByPk(memberPk);
+
+        findAccountTransfer.updateTransferId(member.getNickname());
+
+        return ProfileDto.AccountTransferCodeResponse.builder()
+                .transferCode(findAccountTransfer.getTransferId())
+                .build();
+    }
+
+    public AccountTransfer findAccountTransfer(Long memberPk) {
+        return accountTransferRepository.findByMember_Pk(memberPk)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ACCOUNT_TRANSFER_NOT_FOUND.getMessage()));
+    }
+
+    @Transactional
+    public void transferAccount(AccountTransferDto.TransferAccount transferAccount) {
+        AccountTransfer findAccountTransfer = findAccountTransfer(transferAccount.getTransferId());
+
+        String decryptedDeviceId = rsaService.decodeDeviceId(transferAccount.getEncryptedDeviceId());
+        findAccountTransfer.getMember().updateDeviceId(decryptedDeviceId);
+    }
+
+    public AccountTransfer findAccountTransfer(String transferId) {
+        return accountTransferRepository.findByTransferId(transferId)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.ACCOUNT_TRANSFER_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/main/java/com/sooum/core/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/sooum/core/global/config/security/SecurityConfig.java
@@ -43,7 +43,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/users/login").permitAll()  // 로그인
 //                .requestMatchers(HttpMethod.POST, "/cards/...").hasRole("USER")   // todo 글쓰기 API 완성 시 on
                 .requestMatchers(HttpMethod.POST, "/users/token").hasRole("USER") // 토큰 재발급
-
+                .requestMatchers(HttpMethod.GET, "/profiles/nickname/**").permitAll()
+                .requestMatchers(HttpMethod.GET, "/imgs/upload/user").permitAll()
+                .requestMatchers(HttpMethod.POST, "/settings/transfer").permitAll()
                 // Authenticated
                 .anyRequest().authenticated()
         );

--- a/src/main/java/com/sooum/core/global/exceptionmessage/ExceptionMessage.java
+++ b/src/main/java/com/sooum/core/global/exceptionmessage/ExceptionMessage.java
@@ -18,7 +18,8 @@ public enum ExceptionMessage {
     UNSUPPORTED_IMAGE_FORMAT("지원하지 않는 확장자입니다."),
     IMAGE_REJECTED_BY_MODERATION("부적절한 이미지 파일입니다."),
     FAVORITE_TAG_NOT_FOUND("즐겨찾기한 기록을 찾을 수 없습니다."),
-    ALREADY_Following("이미 팔로우하고 있는 사용자입니다.");
+    ALREADY_Following("이미 팔로우하고 있는 사용자입니다."),
+    ACCOUNT_TRANSFER_NOT_FOUND("계정 이관 코드를 존재하지 않습니다.");
 
     private final String message;
 


### PR DESCRIPTION
* 닉네임 사용 가능성 유무 조회 API는 security에서 permitAll로 변경
* 프로필 수정 시 사진 저장됐는 지 확인 로직 존재 (프로필 사진은 계속해서 다른 이름으로 저장)
* 계정 이관 코드 조회 API는 이관 코드가 DB에 없을 시 저장하고 바로 조회 가능 (만료된 계정 코드는 삭제하고 다시 저장 후 조회) -> DB에서 하나의 계정 이관 코드 레코드만 갖기 위한 설정
* 계정 이관 API에서 암호화된 deviceId를 받도록 구현했고 온보딩때 API호출을 위해 security에서 permitall로 변경
* AwsS3Service에 이미지가 s3에 존재하는 지 확인하는 메소드에 finally로 connection close하도록 변경