### PR TITLE
fix: 프로필 업데이트 서비스 메소드 수정

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -152,7 +152,7 @@ public class FeedService {
     }
 
     private void validateUserImage(CreateCardDto cardDto) {
-        if (imgService.isModeratingImg(cardDto.getImgName())) {
+        if (imgService.isModeratingCardImg(cardDto.getImgName())) {
             throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
         }
 

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -152,12 +152,11 @@ public class FeedService {
     }
 
     private void validateUserImage(CreateCardDto cardDto) {
-        if (imgService.isModeratingCardImg(cardDto.getImgName())) {
-            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
-        }
-
         if(!imgService.isCardImgSaved(cardDto.getImgName())) {
             throw new EntityNotFoundException(ExceptionMessage.IMAGE_NOT_FOUND.getMessage());
+        }
+        if (imgService.isModeratingCardImg(cardDto.getImgName())) {
+            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
         }
     }
 

--- a/boot/external-api/src/main/java/com/sooum/api/img/service/AWSImgService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/img/service/AWSImgService.java
@@ -46,8 +46,13 @@ public class AWSImgService implements ImgService{
      * @return true인 경우 사용 불가능한 사진입니다.
      */
     @Override
-    public boolean isModeratingImg(String imgName) {
+    public boolean isModeratingCardImg(String imgName) {
         return rekognitionService.isModeratingImg(USER_CARD_IMG, imgName);
+    }
+
+    @Override
+    public boolean isModeratingProfileImg(String imgName) {
+        return rekognitionService.isModeratingImg(PROFILE_IMG, imgName);
     }
 
     @Override

--- a/boot/external-api/src/main/java/com/sooum/api/img/service/ImgService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/img/service/ImgService.java
@@ -16,7 +16,10 @@ public interface ImgService {
     default boolean isProfileImgSaved(String profileImgName) {
         return false;
     }
-    default boolean isModeratingImg(String imgName){
+    default boolean isModeratingCardImg(String imgName){
+        return false;
+    }
+    default boolean isModeratingProfileImg(String imgName){
         return false;
     }
     default Link findProfileImgUrl(String imgName){return null;}

--- a/boot/external-api/src/main/java/com/sooum/api/member/service/ProfileService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/service/ProfileService.java
@@ -62,15 +62,24 @@ public class ProfileService {
 
     @Transactional
     public void updateProfile(ProfileDto.ProfileUpdate profileUpdate, Long memberPk) {
-        if (imgService.isModeratingImg(profileUpdate.getProfileImg())) {
-            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
+        Member member = memberService.findByPk(memberPk);
+
+        updateProfileImg(profileUpdate.getProfileImg(), member);
+        member.updateNickname(profileUpdate.getNickname());
+    }
+
+    private void updateProfileImg(String profileImgName, Member member) {
+        if (profileImgName == null) {
+            return;
         }
 
-        if(!imgService.isProfileImgSaved(profileUpdate.getProfileImg())) {
+        if (imgService.isModeratingProfileImg(profileImgName)) {
+            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
+        }
+        if(!imgService.isProfileImgSaved(profileImgName)) {
             throw new EntityNotFoundException(ExceptionMessage.IMAGE_NOT_FOUND.getMessage());
         }
 
-        Member member = memberService.findByPk(memberPk);
-        member.updateProfile(profileUpdate.getNickname(), profileUpdate.getProfileImg());
+        member.updateProfileImgName(profileImgName);
     }
 }

--- a/boot/external-api/src/main/java/com/sooum/api/member/service/ProfileService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/service/ProfileService.java
@@ -73,13 +73,12 @@ public class ProfileService {
             return;
         }
 
-        if (imgService.isModeratingProfileImg(profileImgName)) {
-            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
-        }
         if(!imgService.isProfileImgSaved(profileImgName)) {
             throw new EntityNotFoundException(ExceptionMessage.IMAGE_NOT_FOUND.getMessage());
         }
-
+        if (imgService.isModeratingProfileImg(profileImgName)) {
+            throw new EntityNotFoundException(ExceptionMessage.IMAGE_REJECTED_BY_MODERATION.getMessage());
+        }
         member.updateProfileImgName(profileImgName);
     }
 }

--- a/cloud/src/main/java/com/sooum/client/aws/s3/S3Service.java
+++ b/cloud/src/main/java/com/sooum/client/aws/s3/S3Service.java
@@ -61,8 +61,6 @@ public class S3Service {
                     .build());
         } catch (Exception e) {
             return false;
-        } finally {
-            s3Client.close();
         }
         return true;
     }

--- a/data/core-data/src/main/java/com/sooum/data/member/entity/Member.java
+++ b/data/core-data/src/main/java/com/sooum/data/member/entity/Member.java
@@ -89,8 +89,11 @@ public class Member extends BaseEntity {
         return untilBan;
     }
 
-    public void updateProfile(String nickname, String profileImgName) {
+    public void updateNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public void updateProfileImgName(String profileImgName) {
         this.profileImgName = profileImgName;
     }
 


### PR DESCRIPTION
* 프로필 사진 디렉토리에서 rekognition 동작하도록 수정
* 프로필 사진 저장 안했을 시 로직 처리 추가
* 프로필 사진 검열 메소드 추가로 기존의 isModeratingImg -> isModerationCardImg 이름 변경
* 사진 검열 전에 저장돼있는지 먼저 확인하도록 검증 로직 순서 변경
* s3Client는 재활용 인스턴스로 close하면 안되기 때문에 close 부분 삭제