### PR TITLE
refactor: 이전카드 조회시 삭제되었을 경우 id -1로 반환

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/card/service/DetailFeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/DetailFeedService.java
@@ -58,8 +58,8 @@ public class DetailFeedService {
         if (card instanceof CommentCard commentCard) {
             Card parentCard = feedService.findParentCard(commentCard);
 
-            String previousCardId = isParentCardValid(parentCard) ? parentCard.getPk().toString() : null;
-            Link previousCardImgLink = isParentCardValid(parentCard) ?
+            String previousCardId = resolvePreviousCardPk(parentCard, commentCard.getParentCardPk());
+            Link previousCardImgLink = parentCard != null ?
                     imgService.findCardImgUrl(parentCard.getImgType(),parentCard.getImgName()) : null;
 
             return CommentDetailCardDto.builder()
@@ -80,7 +80,13 @@ public class DetailFeedService {
         throw new IllegalArgumentException(ExceptionMessage.UNHANDLED_OBJECT.getMessage());
     }
 
-    private static boolean isParentCardValid(Card parentCard) {
-        return parentCard != null && !parentCard.isDeleted();
+    private String resolvePreviousCardPk(Card parentCard, Long parentPk) {
+        if (parentCard == null && parentPk != null) {
+            return "-1";
+        }
+        if (parentCard != null) {
+            return parentCard.getPk().toString();
+        }
+        return null;
     }
 }

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -175,10 +175,12 @@ public class FeedService {
 
     public Card findParentCard(CommentCard commentCard) {
         if(commentCard.getParentCardType().equals(CardType.COMMENT_CARD)){
-            return commentCardService.findByPk(commentCard.getParentCardPk());
+            return commentCardService.findOptCommentCard(commentCard.getParentCardPk())
+                    .orElse(null);
         }
         if (commentCard.getParentCardType().equals(CardType.FEED_CARD)){
-            return feedCardService.findByPk(commentCard.getParentCardPk());
+            return feedCardService.findOptFeedCard(commentCard.getParentCardPk())
+                    .orElse(null);
         }
         throw new IllegalArgumentException(ExceptionMessage.UNHANDLED_TYPE.getMessage());
     }

--- a/data/core-data/src/main/java/com/sooum/data/card/service/CommentCardService.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/service/CommentCardService.java
@@ -51,6 +51,10 @@ public class CommentCardService {
                 .orElseThrow(EntityNotFoundException::new);
     }
 
+    public Optional<CommentCard> findOptCommentCard(Long commentCardPk) {
+        return commentCardRepository.findById(commentCardPk);
+    }
+
     public boolean isExistCommentCard(Long commentCardPk) {
         return commentCardRepository.existsById(commentCardPk);
     }

--- a/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
@@ -1,5 +1,6 @@
 package com.sooum.data.card.service;
 
+import com.sooum.data.card.entity.CommentCard;
 import com.sooum.data.card.entity.FeedCard;
 import com.sooum.data.card.repository.FeedCardRepository;
 import com.sooum.data.member.entity.Member;
@@ -38,6 +39,10 @@ public class FeedCardService {
     public FeedCard findFeedCard(Long feedCardPk) {
         return feedCardRepository.findById(feedCardPk)
                 .orElseThrow(EntityNotFoundException::new);
+    }
+
+    public Optional<FeedCard> findOptFeedCard(Long commentCardPk) {
+        return feedCardRepository.findById(commentCardPk);
     }
 
     public boolean isExistFeedCard(Long feedCardPk) {


### PR DESCRIPTION
카드 상세조회에서 전글의 id 반환 부분에서 해당 card가 hard delete 로 변경되어 맞게 수정하였습니다.

이전카드가 존재하지 않을 경우(삭제된경우)
- previousCardId 는 pk로 반환, previousCardImgLink는 null 반환
- isParentDeleted는 true로 반환

으로 구현했습니다~