### PR TITLE
refactor: card hard delete에 따른 유저 탈퇴로직 수정

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/member/service/MemberWithdrawalService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/service/MemberWithdrawalService.java
@@ -14,7 +14,9 @@ import com.sooum.data.report.service.CommentReportService;
 import com.sooum.data.report.service.FeedReportService;
 import com.sooum.data.suspended.entity.Suspended;
 import com.sooum.data.suspended.service.SuspendedService;
+import com.sooum.data.tag.service.CommentTagService;
 import com.sooum.data.tag.service.FavoriteTagService;
+import com.sooum.data.tag.service.FeedTagService;
 import com.sooum.data.visitor.service.VisitorService;
 import com.sooum.global.config.jwt.InvalidTokenException;
 import com.sooum.global.config.jwt.TokenProvider;
@@ -47,6 +49,8 @@ public class MemberWithdrawalService {
     private final RefreshTokenService refreshTokenService;
     private final ProfileImgService profileImgService;
     private final AccountTransferService accountTransferService;
+    private final FeedTagService feedTagService;
+    private final CommentTagService commentTagService;
 
     @Transactional
     public void withdrawMember(Long memberPk, AuthDTO.Token token) throws InvalidTokenException {
@@ -59,9 +63,6 @@ public class MemberWithdrawalService {
 
         cardImgService.updateCardImgNull(memberPk);
 
-        feedCardService.clearWriterByMemberPk(memberPk);
-        commentCardService.clearWriterByMemberPk(memberPk);
-
         feedLikeService.deleteAllMemberLikes(memberPk);
         commentLikeService.deleteAllMemberLikes(memberPk);
 
@@ -69,6 +70,12 @@ public class MemberWithdrawalService {
 
         feedReportService.deleteAllFeedReports(memberPk);
         commentReportService.deleteAllCommentReports(memberPk);
+
+        feedTagService.deleteFeedTag(memberPk);
+        commentTagService.deleteCommentTag(memberPk);
+
+        commentCardService.deleteCommentCardByMemberPk(memberPk);
+        feedCardService.deleteFeedCardByMemberPk(memberPk);
 
         followService.deleteAllFollow(memberPk);
         visitorService.handleVisitorOnMemberWithdraw(memberPk);

--- a/data/core-data/src/main/java/com/sooum/data/card/repository/CommentCardRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/repository/CommentCardRepository.java
@@ -48,6 +48,6 @@ public interface CommentCardRepository extends JpaRepository<CommentCard, Long> 
     List<CommentCard> findCommentCardsNextPage(@Param("memberPk") Long memberPK, @Param("lastPk") Long lastPk, Pageable pageable);
 
     @Modifying
-    @Query("update CommentCard cc set cc.writer = null, cc.isDeleted = true WHERE cc.writer.pk = :memberPk")
-    void clearWriterByMemberPk(@Param("memberPk") Long memberPk);
+    @Query("delete from CommentCard cc WHERE cc.writer.pk = :memberPk")
+    void deleteCommentCardByMemberPk(@Param("memberPk") Long memberPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/card/repository/FeedCardRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/repository/FeedCardRepository.java
@@ -59,6 +59,6 @@ public interface FeedCardRepository extends JpaRepository<FeedCard, Long> {
     List<FeedCard> findCommentCardsNextPage(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, PageRequest pageRequest);
 
     @Modifying
-    @Query("update FeedCard fc set fc.writer = null, fc.isDeleted = true WHERE fc.writer.pk = :memberPk")
-    void clearWriterByMemberPk(@Param("memberPk") Long memberPk);
+    @Query("delete from FeedCard fc WHERE fc.writer.pk = :memberPk")
+    void deleteFeedCardByMemberPk(@Param("memberPk") Long memberPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/card/service/CommentCardService.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/service/CommentCardService.java
@@ -90,7 +90,7 @@ public class CommentCardService {
                 : commentCardRepository.findCommentCardsNextPage(memberPk, lastPk.get(), pageRequest);
     }
 
-    public void clearWriterByMemberPk(Long memberPk) {
-        commentCardRepository.clearWriterByMemberPk(memberPk);
+    public void deleteCommentCardByMemberPk(Long memberPk) {
+        commentCardRepository.deleteCommentCardByMemberPk(memberPk);
     }
 }

--- a/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
@@ -73,7 +73,7 @@ public class FeedCardService {
                 : feedCardRepository.findCommentCardsNextPage(memberPk, lastPk.get(), pageRequest);
     }
 
-    public void clearWriterByMemberPk(Long memberPk) {
-        feedCardRepository.clearWriterByMemberPk(memberPk);
+    public void deleteFeedCardByMemberPk(Long memberPk) {
+        feedCardRepository.deleteFeedCardByMemberPk(memberPk);
     }
 }

--- a/data/core-data/src/main/java/com/sooum/data/tag/repository/CommentTagRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/tag/repository/CommentTagRepository.java
@@ -4,6 +4,7 @@ import com.sooum.data.card.entity.CommentCard;
 import com.sooum.data.tag.entity.CommentTag;
 import com.sooum.data.tag.entity.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -19,4 +20,8 @@ public interface CommentTagRepository extends JpaRepository<CommentTag, Long> {
 
     @Query("SELECT ct.tag FROM CommentTag ct WHERE ct.commentCard = :commentCard")
     List<Tag> findTagsByCommentCard(@Param("commentCard") CommentCard commentCard);
+
+    @Modifying
+    @Query("delete from CommentTag ct where ct.commentCard.writer.pk = :memberPk")
+    void deleteCommentTag(@Param("memberPk") Long memberPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/tag/repository/FeedTagRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/tag/repository/FeedTagRepository.java
@@ -5,6 +5,7 @@ import com.sooum.data.tag.entity.FeedTag;
 import com.sooum.data.tag.entity.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -39,4 +40,7 @@ public interface FeedTagRepository extends JpaRepository<FeedTag, Long> {
     List<FeedTag> findTop5FeedCardsByMemberPk(@Param("favoriteTagList") List<Long> favoriteTagList,
                                               @Param("blockedMemberPks") List<Long> blockedMemberPks);
 
+    @Modifying
+    @Query("delete from FeedTag ft where ft.feedCard.writer.pk = :memberPk")
+   void deleteFeedTag(@Param("memberPk") Long memberPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/tag/service/CommentTagService.java
+++ b/data/core-data/src/main/java/com/sooum/data/tag/service/CommentTagService.java
@@ -42,4 +42,8 @@ public class CommentTagService {
     public void saveAll(List<CommentTag> commentTagList) {
         commentTagRepository.saveAll(commentTagList);
     }
+
+    public void deleteCommentTag(Long memberPk) {
+        commentTagRepository.deleteCommentTag(memberPk);
+    }
 }

--- a/data/core-data/src/main/java/com/sooum/data/tag/service/FeedTagService.java
+++ b/data/core-data/src/main/java/com/sooum/data/tag/service/FeedTagService.java
@@ -35,4 +35,8 @@ public class FeedTagService {
     public void saveAll(List<FeedTag> feedTagList) {
         feedTagRepository.saveAll(feedTagList);
     }
+
+    public void deleteFeedTag(Long memberPk) {
+        feedTagRepository.deleteFeedTag(memberPk);
+    }
 }


### PR DESCRIPTION
카드 삭제시 card hard delete로 변경됨에 따라 유저가 탈퇴했을 때도 기존에는 writer null -> hard delete로 변경하였습니다.
feed_tag, comment_tag 모두 hard delete 처리하였습니다.

close #217 