### PR TITLE
feature: check suspension member

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
@@ -6,25 +6,31 @@ import com.sooum.api.card.service.CardService;
 import com.sooum.api.card.service.CommentInfoService;
 import com.sooum.api.member.dto.AuthDTO;
 import com.sooum.api.member.service.MemberWithdrawalService;
+import com.sooum.data.suspended.service.SuspendedService;
 import com.sooum.global.auth.annotation.CurrentUser;
 import com.sooum.global.responseform.ResponseCollectionModel;
 import com.sooum.global.responseform.ResponseStatus;
 import com.sooum.global.util.NextPageLinkGenerator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class MemberController {
     private final CommentInfoService commentInfoService;
     private final CardService cardService;
     private final MemberWithdrawalService memberWithdrawalService;
+    private final SuspendedService suspendedService;
 
     @GetMapping("/feed-cards")
     public ResponseEntity<?> findMyFeedCards(@CurrentUser Long memberPk, @RequestParam(required = false) Optional<Long> lastId) {
@@ -70,5 +76,16 @@ public class MemberController {
     public ResponseEntity<?> withdrawMember(@CurrentUser Long memberPk, @RequestBody AuthDTO.Token token) {
         memberWithdrawalService.withdrawMember(memberPk, token);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<?> checkSuspendedMember(@RequestParam(value = "deviceId") String deviceId) {
+        Optional<LocalDateTime> suspensionUntil = suspendedService.checkMemberSuspension(deviceId);
+
+        if (suspensionUntil.isEmpty()) {
+            return ResponseEntity.ok("No suspension found.");
+        }
+
+        return ResponseEntity.ok(Map.of("untilBan", suspensionUntil.get()));
     }
 }

--- a/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
@@ -12,7 +12,6 @@ import com.sooum.global.responseform.ResponseCollectionModel;
 import com.sooum.global.responseform.ResponseStatus;
 import com.sooum.global.util.NextPageLinkGenerator;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +24,6 @@ import java.util.Optional;
 @RequestMapping("/members")
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 public class MemberController {
     private final CommentInfoService commentInfoService;
     private final CardService cardService;

--- a/boot/external-api/src/main/java/com/sooum/global/config/security/SecurityConfig.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.sooum.global.config.security;
 
 import com.sooum.global.config.jwt.JwtAuthenticationFilter;
 import com.sooum.global.config.jwt.TokenProvider;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +39,9 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/users/key").permitAll()
                 .requestMatchers(HttpMethod.POST, "/users/sign-up").permitAll()  // 회원가입
                 .requestMatchers(HttpMethod.POST, "/users/login").permitAll()  // 로그인
-//                .requestMatchers(HttpMethod.POST, "/cards/...").hasRole("USER")   // todo 글쓰기 API 완성 시 on
+                .requestMatchers(HttpMethod.GET, "/members").permitAll()
+                .requestMatchers(HttpMethod.POST, "/cards").hasRole("USER")
+                .requestMatchers(HttpMethod.POST, "/cards/{cardPk}").hasRole("USER")
                 .requestMatchers(HttpMethod.POST, "/users/token").hasRole("USER") // 토큰 재발급
                 .requestMatchers(HttpMethod.GET, "/profiles/nickname/{nickname}/available").permitAll()
                 .requestMatchers(HttpMethod.POST, "/settings/transfer").permitAll()
@@ -54,7 +57,7 @@ public class SecurityConfig {
 
         // Token Exception Handling
         http.exceptionHandling(except -> except
-                .authenticationEntryPoint((request, response, authException) -> response.sendError(response.getStatus(), "토큰 오류"))
+                .authenticationEntryPoint((request, response, authException) -> response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰 오류"))
         );
 
         return http.build();

--- a/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
@@ -3,5 +3,8 @@ package com.sooum.data.suspended.repository;
 import com.sooum.data.suspended.entity.Suspended;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SuspendedRepository extends JpaRepository<Suspended, Long> {
+    Optional<Suspended> findByDeviceId(String deviceId);
 }

--- a/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
@@ -2,9 +2,12 @@ package com.sooum.data.suspended.repository;
 
 import com.sooum.data.suspended.entity.Suspended;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface SuspendedRepository extends JpaRepository<Suspended, Long> {
-    Optional<Suspended> findByDeviceId(String deviceId);
+    Optional<Suspended> findByDeviceIdAndUntilBanAfter(String deviceId, LocalDateTime now);
 }

--- a/data/core-data/src/main/java/com/sooum/data/suspended/service/SuspendedService.java
+++ b/data/core-data/src/main/java/com/sooum/data/suspended/service/SuspendedService.java
@@ -5,6 +5,9 @@ import com.sooum.data.suspended.repository.SuspendedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class SuspendedService {
@@ -12,5 +15,10 @@ public class SuspendedService {
 
     public void save(Suspended suspended) {
         suspendedRepository.save(suspended);
+    }
+
+    public Optional<LocalDateTime> checkMemberSuspension(String deviceId) {
+        return suspendedRepository.findByDeviceIdAndUntilBanAfter(deviceId, LocalDateTime.now())
+                .map(Suspended::getUntilBan);
     }
 }


### PR DESCRIPTION
로그인 화면에서 시작하기를 눌렀을 경우, 해당 유저가 정지이력이 있는 탈퇴 계정이었는지 확인하는 API 입니다.

- 정지이력이 있던 (정지이력이 현재시점 이후인지 확인하며) 계정이라면, until_ban을 함께 반환합니다.
- 정지이력이 현재시점 이전이었던 유저들은 추후 batch로 일괄 삭제할 예정입니다.
- no auth 상태에서 api 호출이므로, security config 를 수정하였습니다.

- 글쓰기 API는 role이 USER일 경우에만 가능하도록 security config를 수정하였습니다.

close #177 