### PR TITLE
토큰 인증 필요없는 uri는 헤더에 토큰 뭘 넣든 상관없게 변경

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
@@ -8,19 +8,36 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Set;
+
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
+    private final Set<String> EXCLUDE_AUTH_PATH = Set.of(
+            "/users/key",
+            "/users/sign-up",
+            "/users/login",
+            "/members" ,
+            "/profiles/nickname/**/available"
+    );
+    private static final AntPathMatcher antPathMatcher = new AntPathMatcher();
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
+
+            if (isExcludedPath(request.getRequestURI())) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             tokenProvider.getToken(request).ifPresent(token -> {
                 if (tokenProvider.validateToken(token))
                     setAuthentication(token);
@@ -47,6 +64,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             writer.flush();
             writer.close();
         }
+    }
+
+    public boolean isExcludedPath(String requestPath) {
+        return EXCLUDE_AUTH_PATH.stream()
+                .anyMatch(pattern -> antPathMatcher.match(pattern, requestPath));
     }
 
     private void setAuthentication(String token) {

--- a/boot/external-api/src/main/java/com/sooum/global/config/mvc/WebMvcConfig.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/mvc/WebMvcConfig.java
@@ -26,6 +26,13 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(jwtBlacklistInterceptor);
+        registry.addInterceptor(jwtBlacklistInterceptor)
+                .excludePathPatterns(
+                        "/users/key",
+                        "/users/sign-up",
+                        "/users/login",
+                        "/members" ,
+                        "/profiles/nickname/**/available"
+                );
     }
 }


### PR DESCRIPTION
인터셉터는 설정에서 예외 패턴 추가하여 동작 안하게 구현하였고,
필터는 set에 저장된 패턴을 검사하여 매치되면 토큰 검사하지 않도록 변경함