### PR TITLE
댓글 작성여부 판별 메서드 수정

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/card/service/CommentInfoService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/CommentInfoService.java
@@ -52,7 +52,7 @@ public class CommentInfoService {
                         .createdAt(comment.getCreatedAt())
                         .isLiked(FeedService.isLiked(comment, commentLikes, memberPk))
                         .likeCnt(FeedService.countLikes(comment, commentLikes))
-                        .isCommentWritten(FeedService.isWrittenCommentCard(childComments, memberPk))
+                        .isCommentWritten(FeedService.isWrittenCommentCard(comment, childComments, memberPk))
                         .commentCnt(FeedService.countComments(comment, childComments))
                         .build())
                 .toList());

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/DistanceFeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/DistanceFeedService.java
@@ -55,7 +55,7 @@ public class DistanceFeedService {
                         .distance(DistanceUtils.calculate(feedCard.getLocation(), latitude, longitude))
                         .backgroundImgUrl(imgService.findCardImgUrl(feedCard.getImgType(),feedCard.getImgName()))
                         .createdAt(feedCard.getCreatedAt())
-                        .isCommentWritten(isWrittenCommentCard(commentCardList, memberPk))
+                        .isCommentWritten(isWrittenCommentCard(feedCard, commentCardList, memberPk))
                         .isLiked(isLiked(feedCard, feedLikeList, memberPk))
                         .likeCnt(countLikes(feedCard, feedLikeList))
                         .commentCnt(countComments(feedCard, commentCardList))

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -243,8 +243,10 @@ public class FeedService {
         return !feedCardService.findFeedCard(feedCardPk).getWriter().getPk().equals(writerPk);
     }
 
-    public static boolean isWrittenCommentCard(List<CommentCard> commentCardList, Long memberPk) {
-        return commentCardList.stream().anyMatch(commentCard -> commentCard.getWriter().getPk().equals(memberPk));
+    public static boolean isWrittenCommentCard(Card feedCard, List<CommentCard> commentCardList, Long memberPk) {
+        return commentCardList.stream()
+                .filter(commentCard -> commentCard.getMasterCard().equals(feedCard.getPk()))
+                .anyMatch(commentCard -> commentCard.getWriter().getPk().equals(memberPk));
     }
 
     public static boolean isLiked(FeedCard feed, List<FeedLike> feedLikes, Long memberPk) {

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -243,9 +243,9 @@ public class FeedService {
         return !feedCardService.findFeedCard(feedCardPk).getWriter().getPk().equals(writerPk);
     }
 
-    public static boolean isWrittenCommentCard(Card feedCard, List<CommentCard> commentCardList, Long memberPk) {
+    public static boolean isWrittenCommentCard(Card card, List<CommentCard> commentCardList, Long memberPk) {
         return commentCardList.stream()
-                .filter(commentCard -> commentCard.getMasterCard().equals(feedCard.getPk()))
+                .filter(commentCard -> commentCard.getParentCardPk().equals(card.getPk()))
                 .anyMatch(commentCard -> commentCard.getWriter().getPk().equals(memberPk));
     }
 

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/LatestFeedUseCase.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/LatestFeedUseCase.java
@@ -58,7 +58,7 @@ public class LatestFeedUseCase {
                         .distance(DistanceUtils.calculate(feedCard.getLocation(), latitude, longitude))
                         .backgroundImgUrl(imgService.findCardImgUrl(feedCard.getImgType(),feedCard.getImgName()))
                         .createdAt(feedCard.getCreatedAt())
-                        .isCommentWritten(FeedService.isWrittenCommentCard(commentCards, memberPk))
+                        .isCommentWritten(FeedService.isWrittenCommentCard(feedCard, commentCards, memberPk))
                         .isLiked(FeedService.isLiked(feedCard, feedLikes, memberPk))
                         .likeCnt(FeedService.countLikes(feedCard, feedLikes))
                         .commentCnt(FeedService.countComments(feedCard, commentCards))

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/PopularRetrieveService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/PopularRetrieveService.java
@@ -47,7 +47,7 @@ public class PopularRetrieveService {
                         .createdAt(feed.getCreatedAt())
                         .isLiked(FeedService.isLiked(feed, feedLikes, memberPk))
                         .likeCnt(FeedService.countLikes(feed, feedLikes))
-                        .isCommentWritten(FeedService.isWrittenCommentCard(comments, memberPk))
+                        .isCommentWritten(FeedService.isWrittenCommentCard(feed, comments, memberPk))
                         .commentCnt(FeedService.countComments(feed, comments))
                         .build()
                 )

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/TagFeedInfoService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/TagFeedInfoService.java
@@ -51,7 +51,7 @@ public class TagFeedInfoService {
                         .distance(DistanceUtils.calculate(feedCard.getLocation(), latitude, longitude))
                         .backgroundImgUrl(imgService.findCardImgUrl(feedCard.getImgType(), feedCard.getImgName()))
                         .createdAt(feedCard.getCreatedAt())
-                        .isCommentWritten(FeedService.isWrittenCommentCard(commentCards, memberPk))
+                        .isCommentWritten(FeedService.isWrittenCommentCard(feedCard, commentCards, memberPk))
                         .isLiked(FeedService.isLiked(feedCard, feedLikes, memberPk))
                         .likeCnt(FeedService.countLikes(feedCard, feedLikes))
                         .commentCnt(FeedService.countComments(feedCard, commentCards))


### PR DESCRIPTION
전체 답카드 리스트 중 하나라도 답카드 작성을 했으면 true로 반환되는 문제 발견.
각 피드카드 별로 판단할 수 있도록 파라미터를 추가하여 상기 문제 해결.