### PR TITLE
feat/notification-retrieve-API

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/appversion/controller/AppVersionController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/appversion/controller/AppVersionController.java
@@ -1,0 +1,25 @@
+package com.sooum.api.appversion.controller;
+
+import com.sooum.data.app.repository.AppVersionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/app/version")
+@RequiredArgsConstructor
+public class AppVersionController {
+    private final AppVersionRepository appVersionRepository;
+
+    @GetMapping("/android")
+    public ResponseEntity<String> android() {
+        return ResponseEntity.ok(appVersionRepository.findAndroidLatestVersion());
+    }
+
+    @GetMapping("/ios")
+    public ResponseEntity<String> ios() {
+        return ResponseEntity.ok(appVersionRepository.findIosLatestVersion());
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -5,6 +5,7 @@ import com.sooum.api.card.dto.CreateCommentDto;
 import com.sooum.api.card.dto.CreateFeedCardDto;
 import com.sooum.api.img.service.ImgService;
 import com.sooum.api.member.service.BlackListUseCase;
+import com.sooum.api.notification.service.NotificationUseCase;
 import com.sooum.data.card.entity.*;
 import com.sooum.data.card.entity.imgtype.CardImgType;
 import com.sooum.data.card.entity.parenttype.CardType;
@@ -13,6 +14,7 @@ import com.sooum.data.img.service.CardImgService;
 import com.sooum.data.member.entity.Member;
 import com.sooum.data.member.entity.Role;
 import com.sooum.data.member.service.MemberService;
+import com.sooum.data.notification.service.NotificationHistoryService;
 import com.sooum.data.report.service.CommentReportService;
 import com.sooum.data.report.service.FeedReportService;
 import com.sooum.data.tag.entity.CommentTag;
@@ -52,6 +54,7 @@ public class FeedService {
     private final TokenProvider tokenProvider;
     private final BlackListUseCase blackListUseCase;
     private final PopularFeedService popularFeedService;
+    private final NotificationHistoryService notificationHistoryService;
 
     @Transactional
     public void createFeedCard(Long memberPk, CreateFeedCardDto cardDto, HttpServletRequest request) {
@@ -204,7 +207,7 @@ public class FeedService {
         cardImgService.deleteUserUploadPic(commentCard.getImgName());
         commentLikeService.deleteAllFeedLikes(commentCard.getPk());
         commentReportService.deleteReport(commentCard);
-        //todo notification delete
+        notificationHistoryService.deleteNotification(commentCard.getPk());
     }
 
     private void validateCommentCardOwner(Long commentCardPk, Long writerPk) {
@@ -230,7 +233,7 @@ public class FeedService {
         feedLikeService.deleteAllFeedLikes(feedCard.getPk());
         feedReportService.deleteReport(feedCard.getPk());
         popularFeedService.deletePopularCard(feedCard.getPk());
-        //todo notification delete
+        notificationHistoryService.deleteNotification(feedCard.getPk());
     }
 
     private void validateFeedCardOwner(Long commentCardPk, Long writerPk) {

--- a/boot/external-api/src/main/java/com/sooum/api/notification/controller/NotificationController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/notification/controller/NotificationController.java
@@ -1,0 +1,100 @@
+package com.sooum.api.notification.controller;
+
+import com.sooum.api.notification.dto.NotificationDto;
+import com.sooum.api.notification.service.NotificationUseCase;
+import com.sooum.global.auth.annotation.CurrentUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final NotificationUseCase notificationUseCase;
+
+    @PatchMapping("/{notificationPk}/read")
+    public ResponseEntity<?> updateReadStatus(@CurrentUser Long memberPk,
+                                              @PathVariable(value = "notificationPk") Long notificationPk) {
+        notificationUseCase.setNotificationToRead(memberPk, notificationPk);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/unread-cnt")
+    public ResponseEntity<?> findUnreadNotificationCnt(@CurrentUser Long memberPk) {
+        return ResponseEntity.ok(notificationUseCase.findUnreadNotificationCntResponse(memberPk));
+    }
+
+    @GetMapping("/card/unread-cnt")
+    public ResponseEntity<?> findUnreadCardNotificationCnt(@CurrentUser Long memberPk) {
+        return ResponseEntity.ok(notificationUseCase.findUnreadCardNotificationCntResponse(memberPk));
+    }
+
+    @GetMapping("/like/unread-cnt")
+    public ResponseEntity<?> findUnreadLikeNotificationCnt(@CurrentUser Long memberPk) {
+        return ResponseEntity.ok(notificationUseCase.findUnreadLikeNotificationCntResponse(memberPk));
+    }
+
+    @GetMapping({"/unread", "/unread/{lastId}"})
+    public ResponseEntity<?> findUnreadNotifications(@CurrentUser Long memberPk,
+                                                     @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> unreadNotificationResponses = notificationUseCase.findUnreadNotificationResponses(memberPk, lastId);
+        if (unreadNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(unreadNotificationResponses);
+    }
+
+    @GetMapping({"/card/unread", "/card/unread/{lastId}"})
+    public ResponseEntity<?> findUnreadCardNotifications(@CurrentUser Long memberPk,
+                                                         @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> unreadCardNotificationResponses = notificationUseCase.findUnreadCardNotificationResponses(memberPk, lastId);
+        if (unreadCardNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(unreadCardNotificationResponses);
+    }
+
+    @GetMapping({"/like/unread", "/like/unread/{lastId}"})
+    public ResponseEntity<?> findUnreadLikeNotifications(@CurrentUser Long memberPk,
+                                                         @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> unreadLikeNotificationResponses = notificationUseCase.findUnreadLikeNotificationResponses(memberPk, lastId);
+        if (unreadLikeNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(unreadLikeNotificationResponses);
+    }
+
+    @GetMapping({"/read", "/read/{lastId}"})
+    public ResponseEntity<?> findReadNotifications(@CurrentUser Long memberPk,
+                                                   @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> readNotificationResponses = notificationUseCase.findReadNotificationResponses(memberPk, lastId);
+        if (readNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(readNotificationResponses);
+    }
+
+    @GetMapping({"/card/read", "/card/read/{lastId}"})
+    public ResponseEntity<?> findReadCardNotifications(@CurrentUser Long memberPk,
+                                                       @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> readCardNotificationResponses = notificationUseCase.findReadCardNotificationResponses(memberPk, lastId);
+        if (readCardNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(readCardNotificationResponses);
+    }
+
+    @GetMapping({"/like/read", "/like/read/{lastId}"})
+    public ResponseEntity<?> findReadLikeNotifications(@CurrentUser Long memberPk,
+                                                       @PathVariable(required = false, value = "lastId") Optional<Long> lastId) {
+        List<NotificationDto.CommonNotificationInfo> readLikeNotificationResponses = notificationUseCase.findReadLikeNotificationResponses(memberPk, lastId);
+        if (readLikeNotificationResponses.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(readLikeNotificationResponses);
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/api/notification/dto/NotificationDto.java
+++ b/boot/external-api/src/main/java/com/sooum/api/notification/dto/NotificationDto.java
@@ -1,0 +1,109 @@
+package com.sooum.api.notification.dto;
+
+import com.sooum.data.card.entity.font.Font;
+import com.sooum.data.card.entity.fontsize.FontSize;
+import com.sooum.data.notification.entity.NotificationHistory;
+import com.sooum.data.notification.entity.notificationtype.NotificationType;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.hateoas.Link;
+
+import java.time.LocalDateTime;
+
+public class NotificationDto {
+    @Getter
+    public static class NotificationCntResponse {
+        Long unreadCnt;
+
+        @Builder
+        public NotificationCntResponse(Long unreadCnt) {
+            this.unreadCnt = unreadCnt;
+        }
+    }
+
+    @Getter
+    public abstract static class CommonNotificationInfo {
+        Long notificationId;
+        NotificationType notificationType;
+        LocalDateTime createTime;
+
+    public CommonNotificationInfo(Long notificationId, NotificationType notificationType, LocalDateTime createTime) {
+        this.notificationId = notificationId;
+        this.notificationType = notificationType;
+        this.createTime = createTime;
+    }
+}
+
+    @Getter
+    public static class NotificationInfoResponse extends CommonNotificationInfo {
+
+        Long targetCardId;
+        Link imgUrl;
+        String content;
+        Font font;
+        FontSize fontSize;
+        String nickName;
+
+        @Builder
+        public NotificationInfoResponse(Long notificationId, NotificationType notificationType, LocalDateTime createTime, Long targetCardId, Link imgUrl, String content, Font font, FontSize fontSize, String nickName) {
+            super(notificationId, notificationType, createTime);
+            this.targetCardId = targetCardId;
+            this.imgUrl = imgUrl;
+            this.content = content;
+            this.font = font;
+            this.fontSize = fontSize;
+            this.nickName = nickName;
+        }
+
+        public static CommonNotificationInfo of(NotificationHistory history, Link imgUrl) {
+            return NotificationInfoResponse.builder()
+                    .notificationId(history.getPk())
+                    .targetCardId(history.getTargetCardPk())
+                    .notificationType(history.getNotificationType())
+                    .createTime(history.getCreatedAt())
+                    .imgUrl(imgUrl)
+                    .content(history.getContent())
+                    .font(history.getFont())
+                    .fontSize(history.getFontSize())
+                    .nickName(history.getFromMember().getNickname())
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class DeleteNotificationInfoResponse extends CommonNotificationInfo {
+
+        @Builder
+        public DeleteNotificationInfoResponse(Long notificationId, NotificationType notificationType, LocalDateTime createTime) {
+            super(notificationId, notificationType, createTime);
+        }
+
+        public static DeleteNotificationInfoResponse of(NotificationHistory history) {
+            return DeleteNotificationInfoResponse.builder()
+                    .notificationId(history.getPk())
+                    .notificationType(history.getNotificationType())
+                    .createTime(history.getCreatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    public static class BlockedNotificationInfoResponse extends CommonNotificationInfo {
+        LocalDateTime blockExpirationDateTime;
+
+        @Builder
+        public BlockedNotificationInfoResponse(Long notificationId, NotificationType notificationType, LocalDateTime createTime, LocalDateTime blockExpirationDateTime) {
+            super(notificationId, notificationType, createTime);
+            this.blockExpirationDateTime = blockExpirationDateTime;
+        }
+
+        public static BlockedNotificationInfoResponse of(NotificationHistory history) {
+            return BlockedNotificationInfoResponse.builder()
+                    .notificationId(history.getPk())
+                    .notificationType(history.getNotificationType())
+                    .createTime(history.getCreatedAt())
+                    .blockExpirationDateTime(history.getToMember().getUntilBan())
+                    .build();
+        }
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/api/notification/service/NotificationUseCase.java
+++ b/boot/external-api/src/main/java/com/sooum/api/notification/service/NotificationUseCase.java
@@ -1,0 +1,131 @@
+package com.sooum.api.notification.service;
+
+import com.sooum.api.img.service.AWSImgService;
+import com.sooum.api.notification.dto.NotificationDto;
+import com.sooum.data.notification.entity.NotificationHistory;
+import com.sooum.data.notification.entity.notificationtype.NotificationType;
+import com.sooum.data.notification.service.NotificationHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationUseCase {
+    private final AWSImgService awsImgService;
+
+    private final NotificationHistoryService notificationHistoryService;
+
+    public boolean setNotificationToRead(Long memberPk, Long notificationPk) {
+        if(isNotificationOwner(memberPk, notificationPk)){
+            notificationHistoryService.updateToRead(notificationPk);
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isNotificationOwner(Long memberPk, Long notificationPk) {
+        return notificationHistoryService.findToMember(notificationPk).getPk().equals(memberPk);
+    }
+
+    public NotificationDto.NotificationCntResponse findUnreadNotificationCntResponse(Long memberPk) {
+        return NotificationDto.NotificationCntResponse.builder()
+                .unreadCnt(notificationHistoryService.findUnreadNotificationCount(memberPk))
+                .build();
+    }
+
+    public NotificationDto.NotificationCntResponse findUnreadCardNotificationCntResponse(Long memberPk) {
+        return NotificationDto.NotificationCntResponse.builder()
+                .unreadCnt(notificationHistoryService.findUnreadCardNotificationCount(memberPk))
+                .build();
+    }
+
+    public NotificationDto.NotificationCntResponse findUnreadLikeNotificationCntResponse(Long memberPk) {
+        return NotificationDto.NotificationCntResponse.builder()
+                .unreadCnt(notificationHistoryService.findUnreadLikeNotificationCount(memberPk))
+                .build();
+
+    }
+
+    /**
+     * {@code memberPk}가 읽지않은 전체 알림을 조회하여 DTO로 변환 후 반환합니다.
+     * <p>전체 알림 조회는 시스템 알림이 포함될 수 있기 때문에, 시스템 알림인 경우 알림 화면에 카드 정보가 노출되지 않으니 DTO로 변환 시 imgUrl에 null을 전달합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @return {@literal List<NotificationDto.NotificationInfoResponse>}
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    public List<NotificationDto.CommonNotificationInfo> findUnreadNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+
+        return notificationHistoryService.findUnreadNotifications(memberPk, lastPk).stream()
+                .map(notification -> {
+                    if (isSystemNotification(notification)) {
+                        if (isDeleteNotification(notification)) {
+                            return NotificationDto.DeleteNotificationInfoResponse.of(notification);
+                        }
+                        if (isBlockedNotification(notification)) {
+                            return NotificationDto.BlockedNotificationInfoResponse.of(notification);
+                        }
+                    }
+                    return NotificationDto.NotificationInfoResponse
+                            .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()));
+                })
+                .toList();
+    }
+
+    private static boolean isSystemNotification(NotificationHistory notification) {
+        return isDeleteNotification(notification) || isBlockedNotification(notification);
+    }
+
+    private static boolean isBlockedNotification(NotificationHistory notification) {
+        return notification.getNotificationType().equals(NotificationType.BLOCKED);
+    }
+
+    private static boolean isDeleteNotification(NotificationHistory notification) {
+        return notification.getNotificationType().equals(NotificationType.DELETED);
+    }
+
+    public List<NotificationDto.CommonNotificationInfo> findReadNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryService.findReadNotifications(memberPk, lastPk).stream()
+                .map(notification -> NotificationDto.NotificationInfoResponse
+                        .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()))
+                )
+                .toList();
+    }
+
+    public List<NotificationDto.CommonNotificationInfo> findUnreadCardNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryService.findUnreadCardNotifications(memberPk, lastPk).stream()
+                .map(notification -> NotificationDto.NotificationInfoResponse
+                        .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()))
+                )
+                .toList();
+    }
+
+    public List<NotificationDto.CommonNotificationInfo> findReadCardNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryService.findReadCardNotifications(memberPk, lastPk).stream()
+                .map(notification -> NotificationDto.NotificationInfoResponse
+                        .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()))
+                )
+                .toList();
+    }
+
+    public List<NotificationDto.CommonNotificationInfo> findUnreadLikeNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryService.findUnreadLikeNotifications(memberPk, lastPk).stream()
+                .map(notification -> NotificationDto.NotificationInfoResponse
+                        .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()))
+                )
+                .toList();
+    }
+
+    public List<NotificationDto.CommonNotificationInfo> findReadLikeNotificationResponses(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryService.findReadLikeNotifications(memberPk, lastPk).stream()
+                .map(notification -> NotificationDto.NotificationInfoResponse
+                        .of(notification, awsImgService.findCardImgUrl(notification.getImgType(), notification.getImgName()))
+                )
+                .toList();
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
@@ -27,7 +27,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/users/login", HttpMethod.POST,
             "/members", HttpMethod.GET,
             "/profiles/nickname/**/available", HttpMethod.GET,
-            "/members/suspension", HttpMethod.POST
+            "/members/suspension", HttpMethod.POST,
+            "/app/version/**", HttpMethod.GET
     );
     private static final AntPathMatcher antPathMatcher = new AntPathMatcher();
 

--- a/boot/external-api/src/main/java/com/sooum/global/config/security/SecurityConfig.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/security/SecurityConfig.java
@@ -25,10 +25,6 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
-        // 모든 요청 HTTPS 강제
-//        http.requiresChannel(channelRequestMatcherRegistry ->
-//                channelRequestMatcherRegistry.anyRequest().requiresSecure());
-
         http.csrf(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -46,6 +42,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/members/suspension").permitAll()
                 .requestMatchers(HttpMethod.GET, "/profiles/nickname/{nickname}/available").permitAll()
                 .requestMatchers(HttpMethod.POST, "/settings/transfer").permitAll()
+                .requestMatchers(HttpMethod.GET, "/app/version/**").permitAll()
                 // Authenticated
                 .anyRequest().authenticated()
         );

--- a/data/core-data/src/main/java/com/sooum/data/app/entity/AppVersion.java
+++ b/data/core-data/src/main/java/com/sooum/data/app/entity/AppVersion.java
@@ -1,0 +1,25 @@
+package com.sooum.data.app.entity;
+
+import com.sooum.data.common.entity.BaseEntity;
+import com.sooum.data.member.entity.devicetype.DeviceType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppVersion extends BaseEntity {
+    @Id
+    private Long pk;
+
+    @Enumerated(EnumType.STRING)
+    @NotNull
+    @Column
+    DeviceType deviceType;
+
+    @Column
+    String latestVersion;
+}

--- a/data/core-data/src/main/java/com/sooum/data/app/repository/AppVersionRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/app/repository/AppVersionRepository.java
@@ -1,0 +1,14 @@
+package com.sooum.data.app.repository;
+
+import com.sooum.data.app.entity.AppVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AppVersionRepository extends JpaRepository<AppVersion, Long> {
+    @Query("select a.latestVersion from AppVersion a where a.deviceType = com.sooum.data.member.entity.devicetype.DeviceType.ANDROID")
+    String findAndroidLatestVersion();
+
+    @Query("select a.latestVersion from AppVersion a where a.deviceType = com.sooum.data.member.entity.devicetype.DeviceType.IOS")
+    String findIosLatestVersion();
+
+}

--- a/data/core-data/src/main/java/com/sooum/data/card/repository/FeedCardRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/repository/FeedCardRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface FeedCardRepository extends JpaRepository<FeedCard, Long> {
@@ -68,5 +67,4 @@ public interface FeedCardRepository extends JpaRepository<FeedCard, Long> {
     @Transactional
     @Query("delete from FeedCard fc WHERE fc.writer.pk = :memberPk")
     void deleteFeedCardByMemberPk(@Param("memberPk") Long memberPk);
-
 }

--- a/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
+++ b/data/core-data/src/main/java/com/sooum/data/card/service/FeedCardService.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 

--- a/data/core-data/src/main/java/com/sooum/data/notification/entity/NotificationHistory.java
+++ b/data/core-data/src/main/java/com/sooum/data/notification/entity/NotificationHistory.java
@@ -1,5 +1,9 @@
 package com.sooum.data.notification.entity;
 
+import com.sooum.data.card.entity.font.Font;
+import com.sooum.data.card.entity.fontsize.FontSize;
+import com.sooum.data.card.entity.imgtype.CardImgType;
+import com.sooum.data.card.entity.parenttype.CardType;
 import com.sooum.data.common.entity.BaseEntity;
 import com.sooum.data.member.entity.Member;
 import com.sooum.data.notification.entity.notificationtype.NotificationType;
@@ -10,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 @Getter
 @Entity
@@ -21,6 +26,21 @@ public class NotificationHistory extends BaseEntity {
     @Column(name = "targetCardPk")
     private Long targetCardPk;
 
+    @Column(name = "CONTENT", columnDefinition = "TEXT")
+    private String content;
+
+    @Enumerated(value = EnumType.STRING)
+    private FontSize fontSize;
+
+    @Enumerated(value = EnumType.STRING)
+    private Font font;
+
+    @Enumerated(value = EnumType.STRING)
+    private CardImgType imgType;
+
+    @Column(name = "IMG_NAME")
+    private String imgName;
+
     @Column(name = "isRead")
     private boolean isRead;
 
@@ -28,7 +48,6 @@ public class NotificationHistory extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private NotificationType notificationType;
 
-    @NotNull
     @JoinColumn(name = "fromMember", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @ManyToOne(fetch = FetchType.LAZY)
     private Member fromMember;

--- a/data/core-data/src/main/java/com/sooum/data/notification/repository/NotificationHistoryRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/notification/repository/NotificationHistoryRepository.java
@@ -1,7 +1,225 @@
 package com.sooum.data.notification.repository;
 
+import com.sooum.data.member.entity.Member;
 import com.sooum.data.notification.entity.NotificationHistory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
+
+    /**
+     *{@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 포함한 전체 알림 개수를 검색합니다.
+     * @param memberPk 알림 개수를 조회하는 사용자의 Pk.
+     * @return 알림 개수(Long)
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select count(n) from NotificationHistory n " +
+            "where n.toMember.pk = :memberPk and n.isRead = false ")
+    Long findUnreadNotificationCount(@Param("memberPk") Long memberPk);
+
+    /**
+     *{@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 제외한 카드 알림 개수를 검색합니다.
+     * @param memberPk 알림 개수를 조회하는 사용자의 Pk.
+     * @return 알림 개수(Long)
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select count(n) from NotificationHistory n " +
+            "where n.toMember.pk = :memberPk " +
+                "and n.isRead = false " +
+                "and n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_CARD " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED)")
+    Long findUnreadCardNotificationCount(@Param("memberPk") Long memberPk);
+
+    /**
+     *{@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 제외한 공감 알림 개수를 검색합니다.
+     * @param memberPk 알림 개수를 조회하는 사용자의 Pk.
+     * @return 알림 개수(Long)
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select count(n) from NotificationHistory n " +
+            "where n.toMember.pk = :memberPk " +
+                "and n.isRead = false " +
+                "and (n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.FEED_LIKE " +
+                    "or n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_LIKE) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED)")
+    Long findUnreadLikeNotificationCount(@Param("memberPk") Long memberPk);
+
+    /***
+     * {@code memberPk}가 받은 시스템 알림(정지, 삭제) 중 읽지 않고 한달이 지나지 않은 모든 알림을 페이징하지 않고 한번에 가져옵니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param minusOneMonths 현재로 부터 한달 전 LocalDateTime.
+     * @return {@literal List<NotificationHistory>}
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select n from NotificationHistory n " +
+            "where n.toMember.pk = :memberPk " +
+                "and n.isRead = false " +
+                "and (n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and n.createdAt > :minusOneMonths ")
+    List<NotificationHistory> findBlockOrDeleteNotifications(@Param("memberPk") Long memberPk, @Param("minusOneMonths") LocalDateTime minusOneMonths);
+
+    /**
+     * {@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 제외한 전체 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<Notification>}
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and n.isRead = false " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findUnreadNotifications(@Param("memberPk")Long memberPk, @Param("lastPk") Long lastPk, Pageable page);
+
+    /**
+     *{@code memberPk}가 읽은 시스템 알림(정지, 삭제)을 제외한 전체 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param minusOneDays 현재로 부터 하루 전 LocalDateTime.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<NotificationHistory>}
+     *
+     * @author junwoo
+     * @since 2024-12-14
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and n.isRead = true " +
+                "and n.createdAt > :minusOneDays " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findReadNotifications(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, @Param("minusOneDays") LocalDateTime minusOneDays, Pageable page);
+
+    /**
+     * {@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 제외한 카드 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<Notification>}
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_CARD " +
+                "and n.isRead = false " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findUnreadCardNotifications(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, Pageable page);
+
+    /**
+     *{@code memberPk}가 읽은 시스템 알림(정지, 삭제)을 제외한 카드 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param minusOneDays 현재로 부터 하루 전 LocalDateTime.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<NotificationHistory>}
+     *
+     * @author junwoo
+     * @since 2024-12-14
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_CARD " +
+                "and n.isRead = true " +
+                "and n.createdAt > :minusOneDays " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findReadCardNotifications(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, @Param("minusOneDays") LocalDateTime minusOneDays, Pageable page);
+
+    /**
+     * {@code memberPk}가 읽지 않은 시스템 알림(정지, 삭제)을 제외한 공감 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<Notification>}
+     *
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and (n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.FEED_LIKE " +
+                    "or n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_LIKE) " +
+                "and n.isRead = false " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findUnreadLikeNotifications(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, Pageable page);
+
+    /**
+     *{@code memberPk}가 읽은 시스템 알림(정지, 삭제)을 제외한 공감 알림을 {@code page}개씩 페이징 조회합니다.
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @param minusOneDays 현재로 부터 하루 전 LocalDateTime.
+     * @param page 조회할 알림 개수.
+     * @return {@literal List<NotificationHistory>}
+     *
+     * @author junwoo
+     * @since 2024-12-14
+     */
+    @Query("select n from NotificationHistory n " +
+            "join fetch n.fromMember " +
+            "where n.toMember.pk = :memberPk " +
+                "and (:lastPk is null or n.pk < :lastPk) " +
+                "and (n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.DELETED " +
+                    "or n.notificationType != com.sooum.data.notification.entity.notificationtype.NotificationType.BLOCKED) " +
+                "and (n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.FEED_LIKE " +
+                    "or n.notificationType = com.sooum.data.notification.entity.notificationtype.NotificationType.COMMENT_LIKE) " +
+                "and n.isRead = true " +
+                "and n.createdAt > :minusOneDays " +
+            "order by n.pk desc ")
+    List<NotificationHistory> findReadLikeNotifications(@Param("memberPk") Long memberPk, @Param("lastPk") Long lastPk, @Param("minusOneDays") LocalDateTime minusOneDays, Pageable page);
+
+    @Query("select n.toMember from NotificationHistory n where n.pk = :notificationPk")
+    Member findToMember(@Param("notificationPk") Long notificationPk);
+
+    @Transactional
+    @Modifying
+    @Query("update NotificationHistory n set n.isRead = true where n.pk = :notificationPk")
+    void updateToRead(@Param("notificationPk") Long notificationPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/notification/repository/NotificationHistoryRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/notification/repository/NotificationHistoryRepository.java
@@ -222,4 +222,9 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
     @Modifying
     @Query("update NotificationHistory n set n.isRead = true where n.pk = :notificationPk")
     void updateToRead(@Param("notificationPk") Long notificationPk);
+
+    @Transactional
+    @Modifying
+    @Query("delete from NotificationHistory n where n.targetCardPk = :targetCardPk")
+    void deleteNotification(@Param("targetCardPk") Long targetCardPk);
 }

--- a/data/core-data/src/main/java/com/sooum/data/notification/service/NotificationHistoryService.java
+++ b/data/core-data/src/main/java/com/sooum/data/notification/service/NotificationHistoryService.java
@@ -96,4 +96,8 @@ public class NotificationHistoryService {
     public void updateToRead(Long notificationPk) {
         notificationHistoryRepository.updateToRead(notificationPk);
     }
+
+    public void deleteNotification(Long targetCardPk) {
+        notificationHistoryRepository.deleteNotification(targetCardPk);
+    }
 }

--- a/data/core-data/src/main/java/com/sooum/data/notification/service/NotificationHistoryService.java
+++ b/data/core-data/src/main/java/com/sooum/data/notification/service/NotificationHistoryService.java
@@ -1,11 +1,99 @@
 package com.sooum.data.notification.service;
 
+import com.sooum.data.member.entity.Member;
+import com.sooum.data.notification.entity.NotificationHistory;
 import com.sooum.data.notification.repository.NotificationHistoryRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Stream;
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationHistoryService {
     private final NotificationHistoryRepository notificationHistoryRepository;
+
+    @Transactional(readOnly = true)
+    public Member findToMember(Long notificationPk) {
+        return notificationHistoryRepository.findToMember(notificationPk);
+    }
+
+    @Transactional(readOnly = true)
+    public Long findUnreadNotificationCount(Long memberPk) {
+        return notificationHistoryRepository.findUnreadNotificationCount(memberPk);
+    }
+
+    @Transactional(readOnly = true)
+    public Long findUnreadCardNotificationCount(Long memberPk) {
+        return notificationHistoryRepository.findUnreadCardNotificationCount(memberPk);
+    }
+
+    @Transactional(readOnly = true)
+    public Long findUnreadLikeNotificationCount(Long memberPk) {
+        return notificationHistoryRepository.findUnreadLikeNotificationCount(memberPk);
+    }
+
+    /**
+     * {@code memberPk}가 읽지않은 전체 알림을 조회합니다. 이때 {@code lastPk}가 null이면 최초 조회이므로 읽지 않은 시스템 알림을 포함하여 조회힙니다.
+     * <pre>{@code
+     *     - lastPk가 null.
+     *       Cf.시스템 알림은 최상단에 위치해야 하므로 Stream을 사용하여 시스템 알림 리스트 뒤에 전체 알림 리스트를 더합니다.
+     *     return [시스템 알림, 시스템 알림, ...] + [전체 알림, 전체 알림, ...]
+     *
+     *     - lastPk가 null 아님.
+     *     Cf.최초 조회가 아니기 때문에 최상단에 위치해야 할 시스템 알림을 조회할 필요 없음.
+     *     return [전체 알림, 전체 알림, ...]
+     * }</pre>
+     *
+     * @param memberPk 알림을 조회하는 사용자의 Pk.
+     * @param lastPk 이전 페이지의 마지막 알림 Pk. 최초 조회는 null을 입력합니다.
+     * @return {@literal List<NotificationHistory>}
+     * @since 2024-12-14
+     * @author jungwoo
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findUnreadNotifications(Long memberPk, Optional<Long> lastPk) {
+
+        return lastPk.isEmpty()
+                ? Stream.of(notificationHistoryRepository.findBlockOrDeleteNotifications(memberPk, LocalDateTime.now().minusMonths(1)),
+                        notificationHistoryRepository.findUnreadNotifications(memberPk, null, PageRequest.ofSize(30)))
+                .flatMap(Collection::stream)
+                .toList()
+                : notificationHistoryRepository.findUnreadNotifications(memberPk, lastPk.orElse(null), PageRequest.ofSize(30));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findReadNotifications(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryRepository.findReadNotifications(memberPk, lastPk.orElse(null), LocalDateTime.now().minusDays(1), PageRequest.ofSize(30));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findUnreadCardNotifications(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryRepository.findUnreadCardNotifications(memberPk,lastPk.orElse(null),PageRequest.ofSize(30));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findReadCardNotifications(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryRepository.findReadCardNotifications(memberPk, lastPk.orElse(null), LocalDateTime.now().minusDays(1), PageRequest.ofSize(30));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findUnreadLikeNotifications(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryRepository.findUnreadLikeNotifications(memberPk, lastPk.orElse(null), PageRequest.ofSize(30));
+    }
+
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> findReadLikeNotifications(Long memberPk, Optional<Long> lastPk) {
+        return notificationHistoryRepository.findReadLikeNotifications(memberPk, lastPk.orElse(null), LocalDateTime.now().minusDays(1), PageRequest.ofSize(30));
+    }
+
+    @Transactional
+    public void updateToRead(Long notificationPk) {
+        notificationHistoryRepository.updateToRead(notificationPk);
+    }
 }


### PR DESCRIPTION
**수정 또는 추가된 내용**

*  읽지 않은 전체 알림 개수 조회 API
*  읽지 않은 답카드 알림 개수 조회 API
*  읽지 않은 공감 알림 개수 조회 API
---
*  읽지 않은 전체 알림 정보 조회 API
*  읽지 않은 답카드 알림 정보 조회 API
*  읽지 않은 공감 알림 정보 조회 API
---
*  읽은 전체 알림 정보 조회 API
*  읽은 답카드 알림 정보 조회 API
*  읽은 공감 알림 정보 조회 API
---
*  확인한 알림 읽음 상태 변경 API
---
*  iOS, Android 앱 최신 버전 조회 API
---
*  글 삭제 시 관련 알림 함께 삭제하도록 코드 수정