### PR TITLE
fix: 만료된 토큰도 에러없이 blacklist에 추가하도록 수정

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/member/service/MemberWithdrawalService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/service/MemberWithdrawalService.java
@@ -99,16 +99,13 @@ public class MemberWithdrawalService {
     }
 
     private void addTokensToBlacklist(AuthDTO.Token token) throws InvalidTokenException {
-        tokenProvider.validateToken(token.accessToken());
-        tokenProvider.validateToken(token.refreshToken());
-
         List<Blacklist> blacklistList = List.of(
                 Blacklist.builder()
                         .token(token.accessToken())
-                        .expiredAt(tokenProvider.getExpiration(token.accessToken())).build(),
+                        .expiredAt(tokenProvider.getExpirationAllowExpired(token.accessToken())).build(),
                 Blacklist.builder()
                         .token(token.refreshToken())
-                        .expiredAt(tokenProvider.getExpiration(token.refreshToken())).build()
+                        .expiredAt(tokenProvider.getExpirationAllowExpired(token.refreshToken())).build()
         );
         blacklistService.saveAll(blacklistList);
     }

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/TokenProvider.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/TokenProvider.java
@@ -132,4 +132,20 @@ public class TokenProvider {
     public LocalDateTime getExpiration(String token) {
         return getClaims(token).getExpiration().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
     }
+
+    public LocalDateTime getExpirationAllowExpired(String token) {
+        try {
+            return getClaims(token).getExpiration()
+                    .toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims().getExpiration()
+                    .toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime();
+        } catch (Exception e) {
+            throw new InvalidTokenException();
+        }
+    }
 }


### PR DESCRIPTION
토큰 유효기간 반환시, 만료되었다면 jwt안에서 expiredException 에러가 났습니다. 에러를 잡아 만료가 되어도 blacklist에 추가하도록 수정하였습니다. 