### PR TITLE
refactor: 인기 있는 글 저장할 때 댓글 조건 변경

### DIFF
--- a/boot/batch/src/main/java/com/sooum/batch/card/batch/repository/CommentCardBatchRepository.java
+++ b/boot/batch/src/main/java/com/sooum/batch/card/batch/repository/CommentCardBatchRepository.java
@@ -18,8 +18,8 @@ public interface CommentCardBatchRepository extends CommentCardRepository {
             "where fc.isStory = false " +
                 "and fc.isPublic = true " +
                 "and fc.createdAt >= (current_timestamp - 2 day) " +
-            "group by fc.pk " +
-                "having count(cc.pk) >= 2" +
+            "group by cc.masterCard " +
+                "having count(distinct cc.writer) >= 2" +
             "order by count(fc.pk) desc ")
     List<FeedCard> findPopularCondFeedCards(Pageable pageable);
 }


### PR DESCRIPTION
* 서로 다른 사용자가 두명 이상 댓글을 작성한 피드카드만 저장되도록 변경