### PR TITLE
refactor: 계정이관 시 기존 refreshToken blacklist에 등록

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
+++ b/boot/external-api/src/main/java/com/sooum/api/card/service/FeedService.java
@@ -27,7 +27,7 @@ import com.sooum.data.tag.entity.Tag;
 import com.sooum.data.tag.service.CommentTagService;
 import com.sooum.data.tag.service.FeedTagService;
 import com.sooum.data.tag.service.TagService;
-import com.sooum.global.config.jwt.InvalidTokenException;
+import com.sooum.global.config.jwt.exception.InvalidTokenException;
 import com.sooum.global.config.jwt.TokenProvider;
 import com.sooum.global.exceptionmessage.ExceptionMessage;
 import com.sooum.global.regex.BadWordFiltering;

--- a/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberAuthController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberAuthController.java
@@ -4,12 +4,14 @@ import com.sooum.api.member.dto.AuthDTO;
 import com.sooum.api.member.dto.AuthDTO.*;
 import com.sooum.api.member.service.MemberInfoService;
 import com.sooum.api.rsa.service.RsaUseCase;
+import com.sooum.global.config.jwt.TokenProvider;
 import com.sooum.global.responseform.ResponseEntityModel;
 import com.sooum.global.responseform.ResponseStatus;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,9 +22,11 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 @RequiredArgsConstructor
 @RequestMapping("/users")
 public class MemberAuthController {
-
     private final MemberInfoService memberInfoService;
     private final RsaUseCase rsaUseCase;
+    private final TokenProvider tokenProvider;
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
 
     @GetMapping("/key")
     public ResponseEntity<?> requestPublicKey() {

--- a/boot/external-api/src/main/java/com/sooum/global/auth/interceptor/JwtBlacklistInterceptor.java
+++ b/boot/external-api/src/main/java/com/sooum/global/auth/interceptor/JwtBlacklistInterceptor.java
@@ -1,7 +1,6 @@
 package com.sooum.global.auth.interceptor;
 
 import com.sooum.api.member.service.BlackListUseCase;
-import com.sooum.global.auth.interceptor.exception.JwtBlacklistException;
 import com.sooum.global.config.jwt.TokenProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,11 +25,16 @@ public class JwtBlacklistInterceptor implements HandlerInterceptor {
         if(token == null)
             return true;
 
-        if ((tokenProvider.isAccessToken(token) && blackListUseCase.isAccessTokenExist(token))
-                || (!tokenProvider.isAccessToken(token) && blackListUseCase.isRefreshTokenExist(token))) {
+        if (isBlackListToken(token)) {
             response.setStatus(SC_UNAUTHORIZED);
-            throw new JwtBlacklistException();
+            return false;
         }
+
         return true;
+    }
+
+    private boolean isBlackListToken(String token) {
+        return (tokenProvider.isAccessToken(token) && blackListUseCase.isAccessTokenExist(token))
+                || (!tokenProvider.isAccessToken(token) && blackListUseCase.isRefreshTokenExist(token));
     }
 }

--- a/boot/external-api/src/main/java/com/sooum/global/auth/interceptor/exception/JwtBlacklistException.java
+++ b/boot/external-api/src/main/java/com/sooum/global/auth/interceptor/exception/JwtBlacklistException.java
@@ -1,7 +1,0 @@
-package com.sooum.global.auth.interceptor.exception;
-
-public class JwtBlacklistException extends RuntimeException {
-    public JwtBlacklistException() {
-        super("사용할 수 없는 토큰입니다.");
-    }
-}

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.sooum.global.config.jwt;
 
+import com.sooum.global.config.jwt.exception.InvalidTokenException;
 import com.sooum.global.config.security.path.ExcludeAuthPathProperties;
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,7 +28,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-
             if (isExcludedPath(request)) {
                 filterChain.doFilter(request, response);
                 return;
@@ -41,20 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             },()-> {throw new InvalidTokenException();});
 
             filterChain.doFilter(request, response);
-        } catch (ExpiredJwtException e) {
-            if(e.getClaims().getSubject().equals("AccessToken")) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                PrintWriter writer = response.getWriter();
-                writer.flush();
-                writer.close();
-            }
-            if (e.getClaims().getSubject().equals("RefreshToken")) {
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                PrintWriter writer = response.getWriter();
-                writer.flush();
-                writer.close();
-            }
-        }catch (InvalidTokenException e) {
+        } catch (InvalidTokenException e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             PrintWriter writer = response.getWriter();
             writer.flush();

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/RedisTokenPathPrefix.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/RedisTokenPathPrefix.java
@@ -1,0 +1,15 @@
+package com.sooum.global.config.jwt;
+
+import lombok.Getter;
+
+@Getter
+public enum RedisTokenPathPrefix {
+    ACCESS_TOKEN("blacklist:access:"),
+    REFRESH_TOKEN("blacklist:refresh:");
+
+    private final String prefix;
+
+    RedisTokenPathPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/BlackListTokenException.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/BlackListTokenException.java
@@ -1,0 +1,7 @@
+package com.sooum.global.config.jwt.exception;
+
+public class BlackListTokenException extends RuntimeException {
+    public BlackListTokenException() {
+        super("사용 정지된 토큰입니다.");
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/ExpiredRefreshTokenException.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.sooum.global.config.jwt.exception;
+
+public class ExpiredRefreshTokenException extends RuntimeException {
+    public ExpiredRefreshTokenException() {
+        super("만료된 리프레쉬 토큰입니다");
+    }
+}

--- a/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/InvalidTokenException.java
+++ b/boot/external-api/src/main/java/com/sooum/global/config/jwt/exception/InvalidTokenException.java
@@ -1,4 +1,4 @@
-package com.sooum.global.config.jwt;
+package com.sooum.global.config.jwt.exception;
 
 public class InvalidTokenException extends RuntimeException {
     public InvalidTokenException() {

--- a/boot/external-api/src/main/java/com/sooum/global/exceptionhandler/ValidExceptionHandler.java
+++ b/boot/external-api/src/main/java/com/sooum/global/exceptionhandler/ValidExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.sooum.global.exceptionhandler;
 
 import com.sooum.api.member.exception.BannedUserException;
+import com.sooum.global.config.jwt.exception.BlackListTokenException;
+import com.sooum.global.config.jwt.exception.ExpiredRefreshTokenException;
 import com.sooum.global.responseform.ResponseStatus;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
@@ -55,6 +57,30 @@ public class ValidExceptionHandler {
     public ResponseEntity<Void> internalServerException(Exception e) {
         return ResponseEntity.internalServerError()
                 .build();
+    }
+
+    @ExceptionHandler(BlackListTokenException.class)
+    public ResponseEntity<ResponseStatus> blackListTokenException(BlackListTokenException e) {
+        return ResponseEntity.status(HttpStatus.I_AM_A_TEAPOT)
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.I_AM_A_TEAPOT.value())
+                                .httpStatus(HttpStatus.I_AM_A_TEAPOT)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
+    }
+
+    @ExceptionHandler(ExpiredRefreshTokenException.class)
+    public ResponseEntity<ResponseStatus> expiredRefreshTokenException(ExpiredRefreshTokenException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(
+                        ResponseStatus.builder()
+                                .httpCode(HttpStatus.FORBIDDEN.value())
+                                .httpStatus(HttpStatus.FORBIDDEN)
+                                .responseMessage(e.getMessage())
+                                .build()
+                );
     }
 
     @ExceptionHandler(BannedUserException.class)

--- a/boot/external-api/src/main/resources/application.yml
+++ b/boot/external-api/src/main/resources/application.yml
@@ -49,6 +49,8 @@ exclude-auth-path-patterns:
         method: GET
       - path-pattern: /settings/transfer
         method: POST
+      - path-pattern: /users/token
+        method: POST
 
 exclude-ratelimiter-path-patterns:
   paths:

--- a/data/core-data/src/main/java/com/sooum/data/member/repository/RefreshTokenRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/member/repository/RefreshTokenRepository.java
@@ -7,9 +7,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     @Modifying
     @Transactional
     @Query("delete from RefreshToken r where r.member.pk = :memberPk")
     void deleteRefreshToken(@Param("memberPk") Long memberPk);
+
+    @Query("select r.refreshToken from RefreshToken r where r.member.pk = :memberPk")
+    Optional<String> findRefreshToken(@Param("memberPk") Long memberId);
 }

--- a/data/core-data/src/main/java/com/sooum/data/member/service/RefreshTokenService.java
+++ b/data/core-data/src/main/java/com/sooum/data/member/service/RefreshTokenService.java
@@ -22,6 +22,11 @@ public class RefreshTokenService {
                 .orElseThrow(() -> new EntityNotFoundException("refreshToken을 찾을 수 없습니다."));
     }
 
+    public String findRefreshToken(Long memberPk) {
+        return refreshTokenRepository.findRefreshToken(memberPk)
+                .orElseThrow(() -> new EntityNotFoundException("RefreshToken을 찾을 수 없습니다."));
+    }
+
     public void deleteRefreshToken(Long memberPk) {
         refreshTokenRepository.deleteRefreshToken(memberPk);
     }


### PR DESCRIPTION
* token 재발급 API를 jwt filter를 통과하지 않도록 설정 후 관련 로직을 서비스에서 처리하도록 수정
* 블랙리스트 등록된 토큰은 418 반환