### PR TITLE
feat/rejoin-immediately-after-withdrawal

### DIFF
--- a/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
+++ b/boot/external-api/src/main/java/com/sooum/api/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.sooum.api.member.dto.AuthDTO;
 import com.sooum.api.member.dto.MemberDto;
 import com.sooum.api.member.service.MemberUseCase;
 import com.sooum.api.member.service.MemberWithdrawalService;
+import com.sooum.api.suspended.service.SuspendedUseCase;
 import com.sooum.global.auth.annotation.CurrentUser;
 import com.sooum.global.responseform.ResponseCollectionModel;
 import com.sooum.global.responseform.ResponseEntityModel;
@@ -29,6 +30,7 @@ public class MemberController {
     private final FeedCardUseCase feedCardUseCase;
     private final MemberWithdrawalService memberWithdrawalService;
     private final MemberUseCase memberUseCase;
+    private final SuspendedUseCase suspendedUseCase;
 
     @GetMapping(value = {"/feed-cards", "/{targetMemberId}/feed-cards"})
     public ResponseEntity<?> findMyFeedCards(@RequestParam(required = false) Optional<Long> lastId,
@@ -77,6 +79,12 @@ public class MemberController {
     @DeleteMapping
     public ResponseEntity<?> withdrawMember(@CurrentUser Long memberPk, @RequestBody AuthDTO.Token token) {
         memberWithdrawalService.withdrawMember(memberPk, token);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/rejoin")
+    public ResponseEntity<Void> rejoinMember(@RequestParam String encryptedDeviceId) {
+        suspendedUseCase.deleteMemberSuspensionForRejoin(encryptedDeviceId);
         return ResponseEntity.noContent().build();
     }
 

--- a/boot/external-api/src/main/java/com/sooum/api/suspended/service/SuspendedUseCase.java
+++ b/boot/external-api/src/main/java/com/sooum/api/suspended/service/SuspendedUseCase.java
@@ -5,6 +5,7 @@ import com.sooum.api.suspended.dto.SuspensionDto;
 import com.sooum.data.suspended.service.SuspendedService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -22,5 +23,11 @@ public class SuspendedUseCase {
                         .isBanUser(suspended.isBanUser())
                         .untilBan(suspended.getUntilBan())
                         .build());
+    }
+
+    @Transactional
+    public void deleteMemberSuspensionForRejoin(String encryptedDeviceId) {
+        String deviceId = rsaUseCase.decodeDeviceId(encryptedDeviceId);
+        suspendedService.deleteByDeviceId(deviceId);
     }
 }

--- a/boot/external-api/src/main/resources/application.yml
+++ b/boot/external-api/src/main/resources/application.yml
@@ -53,6 +53,8 @@ exclude-auth-path-patterns:
         method: POST
       - path-pattern: /users/token
         method: POST
+      - path-pattern: /members/rejoin
+        method: POST
 
 exclude-ratelimiter-path-patterns:
   paths:

--- a/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
+++ b/data/core-data/src/main/java/com/sooum/data/suspended/repository/SuspendedRepository.java
@@ -1,11 +1,20 @@
 package com.sooum.data.suspended.repository;
 
 import com.sooum.data.suspended.entity.Suspended;
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface SuspendedRepository extends JpaRepository<Suspended, Long> {
     Optional<Suspended> findByDeviceIdAndUntilBanAfter(String deviceId, LocalDateTime now);
+
+    @Modifying
+    @Transactional
+    @Query("delete from Suspended s where s.deviceId = :deviceId")
+    void deleteByDeviceId(@Param("deviceId") String deviceId);
 }

--- a/data/core-data/src/main/java/com/sooum/data/suspended/service/SuspendedService.java
+++ b/data/core-data/src/main/java/com/sooum/data/suspended/service/SuspendedService.java
@@ -20,4 +20,8 @@ public class SuspendedService {
     public Optional<Suspended> findSuspensionUntilBan(String deviceId) {
         return suspendedRepository.findByDeviceIdAndUntilBanAfter(deviceId, LocalDateTime.now());
     }
+
+    public void deleteByDeviceId(String deviceId) {
+        suspendedRepository.deleteByDeviceId(deviceId);
+    }
 }


### PR DESCRIPTION
- 탈퇴 시 바로 재가입을 가능하도록 하기 위한 API 입니다.
- 암호화된 deviceId param으로 받아 해당 deviceId의 suspended 컬럼을 삭제합니다.
